### PR TITLE
Add a dockerfile for creating a docker image for every change in the …

### DIFF
--- a/.github/workflows/compile-mermaid.yml
+++ b/.github/workflows/compile-mermaid.yml
@@ -1,22 +1,32 @@
-name: 'Build, test and deploy mermaid.cli Docker image'
+name: 'Build, test and deploy mermaid-cli Docker image'
 on:
   push:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env: 
-      IMAGETAG: minlag/mermaid.cli
+
+    env:
+      DOCKERFILE: DockerfileBuild
+      IMAGENAME: mermaid-cli
     steps:
-    
     - uses: actions/checkout@v2
       with:
         fetch-depth: 2
 
+    - name: Convert repository name to lower case
+      run: echo "::set-env name=GITHUB_REPOSITORY_LOWER_CASE::$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')"
+
+    - name: Get release version
+      run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_SHA} | cut -c1-6)
+
+    - name: Create image tag
+      run: echo "::set-env name=IMAGETAG::${{env.GITHUB_REPOSITORY_LOWER_CASE}}/$IMAGENAME:${{env.RELEASE_VERSION}}"
+
     - name: Docker build
-      run: docker build -t $IMAGETAG:$GITHUB_SHA .
+      run: docker build -t ${{env.IMAGETAG}} . -f $DOCKERFILE
  
     - name: Test if the CLI actually works
-      run: docker run -v $(pwd):/data $IMAGETAG:$GITHUB_SHA -i ./test/sequence.mmd -o ./test/sequence.svg
+      run: for i in $(ls test/*.mmd); do docker run -v $(pwd):/data ${{env.IMAGETAG}} -i /data/$i; done
 
     # For manual inspection of the generated artifacts
     - uses: actions/upload-artifact@v1
@@ -24,15 +34,15 @@ jobs:
         name: output
         path: ./test
 
-    - name: Docker Build & Push to Docker Hub
-      uses: opspresso/action-docker@master
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
       with:
-        args: --docker
-      env:
-        USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        DOCKERFILE: "Dockerfile"
-        IMAGE_NAME: ${{ env.IMAGETAG }}
-        TAG_NAME: ${{ env.GITHUB_SHA }}
-        LATEST: "true"
+        name: ${{env.GITHUB_REPOSITORY_LOWER_CASE}}/${{env.IMAGENAME}}
+        username: $GITHUB_ACTOR
+        password: ${{ secrets.GITHUB_TOKEN }}
+        registry: docker.pkg.github.com
+        dockerfile: ${{env.DOCKERFILE}}
+        snapshot: true
+        tags: "latest,${{ env.RELEASE_VERSION }}"
+
     

--- a/DockerfileBuild
+++ b/DockerfileBuild
@@ -1,0 +1,26 @@
+FROM node:current-slim AS build
+
+WORKDIR /app
+
+COPY * /app/
+
+RUN rm package-lock.json \
+    && yarn \
+    && chmod 755 copy_modules.sh \
+    && ./copy_modules.sh \
+    && yarn prepublishOnly \
+    && yarn pack
+
+FROM node:current-slim AS mermaid-cli-current
+
+WORKDIR /app
+
+COPY --from=build /app/mermaid-js-mermaid-cli-*.tgz /install/
+COPY --from=build /app/puppeteer-config.json /puppeteer-config.json
+
+RUN yarn add $(ls -d /install/*.tgz) \
+    && apt-get update \
+    && apt-get install -y gconf-service libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxss1 libxtst6 libappindicator1 libnss3 libasound2 libatk1.0-0 libc6 ca-certificates fonts-liberation lsb-release xdg-utils wget
+    
+ENTRYPOINT ["yarn", "mmdc", "-p", "/puppeteer-config.json"]
+CMD [ "--help" ]


### PR DESCRIPTION
With this PR we implement a CI for every change made in the repository.
More concrete, we build a new yarn package and deploy it into a docker image. The docker image itself is tested against the diagrams in the test/ folder. Finally, if the testing succeeds, the docker image is published into the Github docker registry.
-- An automatic update of the version number is still missing.