### PR TITLE
Publish to docker com

### DIFF
--- a/.github/workflows/compile-mermaid.yml
+++ b/.github/workflows/compile-mermaid.yml
@@ -18,16 +18,16 @@ jobs:
       run: echo "::set-env name=GITHUB_REPOSITORY_LOWER_CASE::$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')"
 
     - name: Get release version
-      run: echo ::set-env name=RELEASE_VERSION::$(echo ${ GITHUB_SHA } | cut -c1-6)
+      run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_SHA} | cut -c1-6)
 
     - name: Create image tag
-      run: echo "::set-env name=IMAGETAG::${{ env.GITHUB_REPOSITORY_LOWER_CASE }}/$IMAGENAME:${{ env.RELEASE_VERSION }}"
+      run: echo "::set-env name=IMAGETAG::${{env.GITHUB_REPOSITORY_LOWER_CASE}}/$IMAGENAME:${{env.RELEASE_VERSION}}"
 
     - name: Docker build
       run: docker build -t ${{env.IMAGETAG}} . -f $DOCKERFILE
  
     - name: Test if the CLI actually works
-      run: for i in $(ls test/*.mmd); do docker run -v $(pwd):/data ${{ env.IMAGETAG }} -i /data/$i; done
+      run: for i in $(ls test/*.mmd); do docker run -v $(pwd):/data ${{env.IMAGETAG}} -i /data/$i; done
 
     # For manual inspection of the generated artifacts
     - uses: actions/upload-artifact@v1
@@ -38,22 +38,22 @@ jobs:
     - name: Publish to Github Registry
       uses: elgohr/Publish-Docker-Github-Action@2.17
       with:
-        name: ${{ env.GITHUB_REPOSITORY_LOWER_CASE }}/${{ env.IMAGENAME }}
+        name: ${{env.GITHUB_REPOSITORY_LOWER_CASE}}/${{env.IMAGENAME}}
         username: $GITHUB_ACTOR
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{secrets.GITHUB_TOKEN}}
         registry: docker.pkg.github.com
-        dockerfile: ${{ env.DOCKERFILE }}
+        dockerfile: ${{env.DOCKERFILE}}
         snapshot: true
-        tags: "latest,${{ env.RELEASE_VERSION }}"
+        tags: "latest,${{env.RELEASE_VERSION}}"
 
     - name: Publish to Docker.io Registry
       uses: elgohr/Publish-Docker-Github-Action@2.17
       with:
-        name: ${{ env.DOCKER_IO_REPOSITORY }}
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        dockerfile: ${{ env.DOCKERFILE }}
+        name: ${{env.DOCKER_IO_REPOSITORY}}
+        username: ${{secrets.DOCKER_USERNAME}}
+        password: ${{secrets.DOCKER_PASSWORD}}
+        dockerfile: ${{env.DOCKERFILE}}
         snapshot: true
-        tags: "latest,${{ env.RELEASE_VERSION }}"
+        tags: "latest,${{env.RELEASE_VERSION}}"
 
     

--- a/.github/workflows/compile-mermaid.yml
+++ b/.github/workflows/compile-mermaid.yml
@@ -36,7 +36,7 @@ jobs:
         path: ./test
 
     - name: Publish to Github Registry
-      uses: elgohr/Publish-Docker-Github-Action@v1.0.0
+      uses: elgohr/Publish-Docker-Github-Action@2.17
       with:
         name: ${{ env.GITHUB_REPOSITORY_LOWER_CASE }}/${{ env.IMAGENAME }}
         username: $GITHUB_ACTOR
@@ -47,7 +47,7 @@ jobs:
         tags: "latest,${{ env.RELEASE_VERSION }}"
 
     - name: Publish to Docker.io Registry
-      uses: elgohr/Publish-Docker-Github-Action@v1.0.0
+      uses: elgohr/Publish-Docker-Github-Action@2.17
       with:
         name: ${{ env.DOCKER_IO_REPOSITORY }}
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/compile-mermaid.yml
+++ b/.github/workflows/compile-mermaid.yml
@@ -8,6 +8,7 @@ jobs:
     env:
       DOCKERFILE: DockerfileBuild
       IMAGENAME: mermaid-cli
+      DOCKER_IO_REPOSITORY: minlag/mermaid-cli
     steps:
     - uses: actions/checkout@v2
       with:
@@ -17,16 +18,16 @@ jobs:
       run: echo "::set-env name=GITHUB_REPOSITORY_LOWER_CASE::$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')"
 
     - name: Get release version
-      run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_SHA} | cut -c1-6)
+      run: echo ::set-env name=RELEASE_VERSION::$(echo ${ GITHUB_SHA } | cut -c1-6)
 
     - name: Create image tag
-      run: echo "::set-env name=IMAGETAG::${{env.GITHUB_REPOSITORY_LOWER_CASE}}/$IMAGENAME:${{env.RELEASE_VERSION}}"
+      run: echo "::set-env name=IMAGETAG::${{ env.GITHUB_REPOSITORY_LOWER_CASE }}/$IMAGENAME:${{ env.RELEASE_VERSION }}"
 
     - name: Docker build
       run: docker build -t ${{env.IMAGETAG}} . -f $DOCKERFILE
  
     - name: Test if the CLI actually works
-      run: for i in $(ls test/*.mmd); do docker run -v $(pwd):/data ${{env.IMAGETAG}} -i /data/$i; done
+      run: for i in $(ls test/*.mmd); do docker run -v $(pwd):/data ${{ env.IMAGETAG }} -i /data/$i; done
 
     # For manual inspection of the generated artifacts
     - uses: actions/upload-artifact@v1
@@ -34,14 +35,24 @@ jobs:
         name: output
         path: ./test
 
-    - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+    - name: Publish to Github Registry
+      uses: elgohr/Publish-Docker-Github-Action@v1.0.0
       with:
-        name: ${{env.GITHUB_REPOSITORY_LOWER_CASE}}/${{env.IMAGENAME}}
+        name: ${{ env.GITHUB_REPOSITORY_LOWER_CASE }}/${{ env.IMAGENAME }}
         username: $GITHUB_ACTOR
         password: ${{ secrets.GITHUB_TOKEN }}
         registry: docker.pkg.github.com
-        dockerfile: ${{env.DOCKERFILE}}
+        dockerfile: ${{ env.DOCKERFILE }}
+        snapshot: true
+        tags: "latest,${{ env.RELEASE_VERSION }}"
+
+    - name: Publish to Docker.io Registry
+      uses: elgohr/Publish-Docker-Github-Action@v1.0.0
+      with:
+        name: ${{ env.DOCKER_IO_REPOSITORY }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        dockerfile: ${{ env.DOCKERFILE }}
         snapshot: true
         tags: "latest,${{ env.RELEASE_VERSION }}"
 


### PR DESCRIPTION
It is hard to use github package registry at the moment, because users cannot download docker images anonymously. Therefore, we implemented an extra step in the build and test action to also publsih to docker.io.