### PR TITLE
Try catch to avoid unhandled rejection

### DIFF
--- a/src-test/test.js
+++ b/src-test/test.js
@@ -63,10 +63,10 @@ async function compileAll() {
           if (!expectError) return resultP;
           try {
             await resultP;
-            return Promise.reject(new Error(`Expected ${file} to fail, but it succeeded`));
           } catch (err) {
             return Promise.resolve(`compling ${file} produced an error, which is well`);
           }
+          throw new Error(`Expected ${file} to fail, but it succeeded`);
         })
       ));
     });

--- a/src-test/test.js
+++ b/src-test/test.js
@@ -64,7 +64,7 @@ async function compileAll() {
           try {
             await resultP;
           } catch (err) {
-            return Promise.resolve(`compling ${file} produced an error, which is well`);
+            return `compling ${file} produced an error, which is well`;
           }
           throw new Error(`Expected ${file} to fail, but it succeeded`);
         })

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ const deviceScaleFactor = parseInt(scale || 1, 10);
     }
   }, definition, mermaidConfig, myCSS)
   if (result.status === 'error') {
-    error(result.error.message);
+    error(result.message);
   }
 
   if (output.endsWith('svg')) {

--- a/test/invalid.expect-error.mmd
+++ b/test/invalid.expect-error.mmd
@@ -1,0 +1,2 @@
+sequenceDiagram
+  Nothing:Valid

--- a/todo.md
+++ b/todo.md
@@ -1,2 +1,1 @@
-- When input is empty string or wrong data(buffer)
 - Write some tests


### PR DESCRIPTION
## :bookmark_tabs: Summary
Present nice error message when mermaid source cannot be parsed.

## :straight_ruler: Design Decisions

It seems that the mermaid package's parse error overrides `Error::message`. This means it's necessary to catch the error within the browser context, so we can call `error.message` at that point. Otherwise, the formatting logic would need to be duplicated in this cli.

This change is not just for cleaner output&mdash;node currently fails the script with an "UnhandledPromiseRejectionWarning", and warns that this will not be supported in the future.

I needed to modify the test script, as I now have a case that _expects_ an error. The implementation of that code is as clear as I could make it, but I'd love suggestions on how to improve it.

Also, I wasn't able to run the tests locally. Not 100% sure that they worked.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [ ] :bookmark: targeted `develop` branch _I couldn't find a develop branch in this repo_
