### PR TITLE
Adjust PDF page size to fit chart size

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,10 +29,11 @@ commander
   .option('-c, --configFile [configFile]', 'JSON configuration file for mermaid. Optional')
   .option('-C, --cssFile [cssFile]', 'CSS file for the page. Optional')
   .option('-s, --scale [scale]', 'Puppeteer scale factor, default 1. Optional')
+  .option('-f, --pdfFit', 'Scale PDF to fit chart')
   .option('-p --puppeteerConfigFile [puppeteerConfigFile]', 'JSON configuration file for puppeteer. Optional')
   .parse(process.argv)
 
-let { theme, width, height, input, output, backgroundColor, configFile, cssFile, puppeteerConfigFile, scale } = commander
+let { theme, width, height, input, output, backgroundColor, configFile, cssFile, puppeteerConfigFile, scale, pdfFit } = commander
 
 // check input file
 if (!input) {
@@ -127,17 +128,24 @@ const deviceScaleFactor = parseInt(scale || 1, 10);
     await page.setViewport({ width: clip.x + clip.width, height: clip.y + clip.height, deviceScaleFactor })
     await page.screenshot({ path: output, clip, omitBackground: backgroundColor === 'transparent' })
   } else { // pdf
-    const clip = await page.$eval('svg', svg => {
-      const react = svg.getBoundingClientRect()
-      return { x: react.left, y: react.top, width: react.width, height: react.height }
-    })
-    await page.pdf({
-      path: output,
-      printBackground: backgroundColor !== 'transparent',
-      width: (Math.ceil(clip.width) + clip.x*2) + 'px',
-      height: (Math.ceil(clip.height) + clip.y*2) + 'px',
-      pageRanges: '1-1',
-    })
+    if (pdfFit) {
+      const clip = await page.$eval('svg', svg => {
+        const react = svg.getBoundingClientRect()
+        return { x: react.left, y: react.top, width: react.width, height: react.height }
+      })
+      await page.pdf({
+        path: output,
+        printBackground: backgroundColor !== 'transparent',
+        width: (Math.ceil(clip.width) + clip.x*2) + 'px',
+        height: (Math.ceil(clip.height) + clip.y*2) + 'px',
+        pageRanges: '1-1',
+      })
+    } else {
+      await page.pdf({
+        path: output,
+        printBackground: backgroundColor !== 'transparent'
+      })
+    }
   }
   await browser.close()
 })()

--- a/src/index.js
+++ b/src/index.js
@@ -127,7 +127,17 @@ const deviceScaleFactor = parseInt(scale || 1, 10);
     await page.setViewport({ width: clip.x + clip.width, height: clip.y + clip.height, deviceScaleFactor })
     await page.screenshot({ path: output, clip, omitBackground: backgroundColor === 'transparent' })
   } else { // pdf
-    await page.pdf({ path: output, printBackground: backgroundColor !== 'transparent' })
+    const clip = await page.$eval('svg', svg => {
+      const react = svg.getBoundingClientRect()
+      return { x: react.left, y: react.top, width: react.width, height: react.height }
+    })
+    await page.pdf({
+      path: output,
+      printBackground: backgroundColor !== 'transparent',
+      width: (Math.ceil(clip.width) + clip.x*2) + 'px',
+      height: (Math.ceil(clip.height) + clip.y*2) + 'px',
+      pageRanges: '1-1',
+    })
   }
   await browser.close()
 })()


### PR DESCRIPTION
## :bookmark_tabs: Summary

This patch adjust the PDF page size in order to fit the chart dimension.

## :straight_ruler: Design Decisions

(ported from https://github.com/mermaidjs/mermaid.cli/pull/53)

Currently PDFs produced by the tool have a fixed page size, independent from the chart size and dictated by the internal behavior of Puppeteer (the documentation says that in the absence of specific options the page size is always Letter).

This produces pages with excessive blank spaces (as mentioned in #48) and is also an anomaly with respect to results obtained with other output formats, since both SVGs and PNGs do fit perfectly the chart size.

This patch adjust the PDF page size in order to fit the chart dimension, also including the margins automatically added by Chromium, resulting in PDFs without blank spaces.

The patch has been tested with all the sample files.

### :clipboard: Tasks
Make sure you
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `master` branch 
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
