### PR TITLE
Group dependebot Pull Requests

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,4 +1,5 @@
 feature: ['feature/*', 'feat/*']
 fix: fix/*
 chore: chore/*
+dependencies: dependabot/*
 fixed-branch: fixed-branch-name

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,6 +11,9 @@ categories:
       - 'bug'
   - title: '🧰 Maintenance'
     label: 'chore'
+  - title: 📦 Dependency updates
+    labels:
+      - dependencies
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 template: |
   ## Changes


### PR DESCRIPTION
## :bookmark_tabs: Summary
We would like a better release note, where all PRs made by dependebot are grouped and placed at the bottom of the release note.

### :clipboard: Tasks
Make sure you
- [+] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [+] :computer: have added unit/e2e tests (if appropriate) 
- [+] :bookmark: targeted `master` branch 
