### PR TITLE
Replace `fregante/setup-git-token` with `setup-git-user`

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -14,7 +14,7 @@ jobs:
       DOCKER_IO_REPOSITORY: minlag/mermaid-cli
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: fregante/setup-git-user@v1
 
     - uses: actions/setup-node@v1

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -15,9 +15,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - uses: fregante/setup-git-token@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: fregante/setup-git-user@v1
 
     - uses: actions/setup-node@v1
       with:


### PR DESCRIPTION
In the v2 of `actions/checkout`, setting the token is no longer necessary, so I created a new config-less action to just set the git user: https://github.com/fregante/setup-git-user