### PR TITLE
Install convert-svg-to-png for e2e testing

### DIFF
--- a/.github/workflows/compile-mermaid.yml
+++ b/.github/workflows/compile-mermaid.yml
@@ -37,7 +37,7 @@ jobs:
       run: docker build -t ${{env.IMAGETAG}} . -f $DOCKERFILE
 
     - name: Setup test environment
-      run: npm install --global convert-svg-to-png
+      run: sudo npm install --global convert-svg-to-png
       
     - name: Run e2e tests
       run: bash run-tests.sh ${{env.INPUT_DATA}} ${{env.IMAGETAG}}

--- a/.github/workflows/compile-mermaid.yml
+++ b/.github/workflows/compile-mermaid.yml
@@ -43,7 +43,7 @@ jobs:
       run: bash run-tests.sh ${{env.INPUT_DATA}} ${{env.IMAGETAG}}
       
     - name: Convert all svg files to png before uploading for automatic inspection
-      run: for i in $(ls ${{env.INPUT_DATA}}/*.svg); do $(npm bin)/convert-svg-to-png ${{env.INPUT_DATA}}/$i ${{env.INPUT_DATA}}/$i-convert-svg-to-png.png; done
+      run: for i in $(ls ${{env.INPUT_DATA}}/*.svg); do $(npm bin)/convert-svg-to-png ${{env.INPUT_DATA}}/$i ${{env.INPUT_DATA}}/$(basename $i)-convert-svg-to-png.png; done
 
     - name: Upload diagrams for manual inspection
       uses: actions/upload-artifact@v1

--- a/.github/workflows/compile-mermaid.yml
+++ b/.github/workflows/compile-mermaid.yml
@@ -36,6 +36,9 @@ jobs:
     - name: Docker build
       run: docker build -t ${{env.IMAGETAG}} . -f $DOCKERFILE
 
+    - name: Setup test environment
+      run: npm install --global convert-svg-to-png
+      
     - name: Run e2e tests
       run: bash run-tests.sh ${{env.INPUT_DATA}} ${{env.IMAGETAG}}
 

--- a/.github/workflows/compile-mermaid.yml
+++ b/.github/workflows/compile-mermaid.yml
@@ -37,7 +37,7 @@ jobs:
       run: docker build -t ${{env.IMAGETAG}} . -f $DOCKERFILE
 
     - name: Setup test environment
-      run: sudo npm install --global convert-svg-to-png
+      run: npm install convert-svg-to-png
       
     - name: Run e2e tests
       run: bash run-tests.sh ${{env.INPUT_DATA}} ${{env.IMAGETAG}}

--- a/.github/workflows/compile-mermaid.yml
+++ b/.github/workflows/compile-mermaid.yml
@@ -41,6 +41,9 @@ jobs:
       
     - name: Run e2e tests
       run: bash run-tests.sh ${{env.INPUT_DATA}} ${{env.IMAGETAG}}
+      
+    - name: Convert all svg files to png before uploading for automatic inspection
+      run: for i in $(ls ${{env.INPUT_DATA}}/*.svg); do $(npm bin)/convert-svg-to-png ${{env.INPUT_DATA}}/$i ${{env.INPUT_DATA}}/$i-convert-svg-to-png.png; done
 
     - name: Upload diagrams for manual inspection
       uses: actions/upload-artifact@v1

--- a/.github/workflows/compile-mermaid.yml
+++ b/.github/workflows/compile-mermaid.yml
@@ -35,15 +35,14 @@ jobs:
 
     - name: Docker build
       run: docker build -t ${{env.IMAGETAG}} . -f $DOCKERFILE
-
-    - name: Setup test environment
-      run: npm install convert-svg-to-png
-      
+   
     - name: Run e2e tests
       run: bash run-tests.sh ${{env.INPUT_DATA}} ${{env.IMAGETAG}}
       
     - name: Convert all svg files to png before uploading for automatic inspection
-      run: for i in $(ls ${{env.INPUT_DATA}}/*.svg); do $(npm bin)/convert-svg-to-png ${{env.INPUT_DATA}}/$i ${{env.INPUT_DATA}}/$(basename $i)-convert-svg-to-png.png; done
+      run: |
+        npm install convert-svg-to-png
+        $(npm bin)/convert-svg-to-png ${{env.INPUT_DATA}}/*.svg
 
     - name: Upload diagrams for manual inspection
       uses: actions/upload-artifact@v1

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -4,7 +4,6 @@ IMAGETAG=$2
 
 # Test if the CLI actually works (PNG)
 for i in $(ls $INPUT_DATA/*.mmd); do docker run -v $(pwd):/data $IMAGETAG -i /data/$i -o /data/$i.png -w 800; done
-for i in $(ls $INPUT_DATA/*.mmd); do docker run -v $(pwd):/data $IMAGETAG -i /data/$i -o /data/$i.svg -w 800; done
 for i in $(ls $INPUT_DATA/*.mmd); do cat $i | docker run -i -v $(pwd):/data $IMAGETAG -o /data/$i-stdin.png -w 800; done
 
 # Test if the CLI actually works (PDF)

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -4,6 +4,7 @@ IMAGETAG=$2
 
 # Test if the CLI actually works (PNG)
 for i in $(ls $INPUT_DATA/*.mmd); do docker run -v $(pwd):/data $IMAGETAG -i /data/$i -o /data/$i.png -w 800; done
+for i in $(ls $INPUT_DATA/*.mmd); do docker run -v $(pwd):/data $IMAGETAG -i /data/$i -o /data/$i.svg -w 800; done
 for i in $(ls $INPUT_DATA/*.mmd); do cat $i | docker run -i -v $(pwd):/data $IMAGETAG -o /data/$i-stdin.png -w 800; done
 
 # Test if the CLI actually works (PDF)


### PR DESCRIPTION
Percy testing framework does not support svgs. In some cases, we want to export svgs and see that working.
