### PR TITLE
Bump mermaid to 8.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,13 @@
   "dependencies": {
     "chalk": "^4.1.0",
     "commander": "^6.0.0",
-    "puppeteer": "^5.0.0"
+    "puppeteer": "^5.0.0",
+    "mermaid": "8.8.4",
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free-webfonts": "^1.0.9",
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.7.0",
-    "mermaid": "^8.8.1",
     "standard": "^16.0.1",
     "yarn-upgrade-all": "^0.5.2"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "chalk": "^4.1.0",
     "commander": "^6.0.0",
     "puppeteer": "^5.0.0",
-    "mermaid": "8.8.4",
+    "mermaid": "8.8.4"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free-webfonts": "^1.0.9",


### PR DESCRIPTION
The last version set in package.json for mermaid is 8.8.1, while the last released mermaid version is 8.8.4.
For whatever reason dependebot did not update package.json with the new mermaid versions.
