### PR TITLE
Fix Markdown parsing, add more verbose output

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -129,7 +129,7 @@ if (cssFile) {
 
 const info = message => {
   if (!quiet) {
-    console.log(message)
+    console.info(message)
   }
 }
 

--- a/test-positive/no-charts.md
+++ b/test-positive/no-charts.md
@@ -1,0 +1,10 @@
+# Hello!
+
+This is a *markdown* file that contains no mermaid charts.
+
+```
+  def test():
+    pass
+```
+
+mermaid-cli should not crash while handling this case.


### PR DESCRIPTION
## :bookmark_tabs: Summary

- Fix exception in case no charts were found in Markdown file
- Log depending on type of input (Markdown or mermaid): Number of charts
  found in Markdown file
- Add --quiet flag to suppress these new log message

`String.match` returns null if nothing was matched - the PR fixes handling this case.
Also adds more log output that can be suppressed with `-q/--quiet`.
Explains in description for `--input` flag how .md files are treated.

Resolves #160

## :straight_ruler: Design Decisions

Calling mermaid-cli on a Markdown file that does not contain mermaid charts should not crash the application. Neither should it report an error or return a non-null status code as it might break use cases where someone blindly runs it on a collection of Markdown files.
I did not apply the standard.js linter/formatter as the existing code base is not formatted either.
`--quiet` suppresses info but not error messages - not sure if that is desired behavior.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
