### PR TITLE
Add test for #165

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -11,3 +11,8 @@ for i in $(ls $INPUT_DATA/*.mmd); do cat $i | docker run -i -v $(pwd):/data $IMA
 # Test if the CLI actually works (PDF)
 for i in $(ls $INPUT_DATA/*.mmd); do docker run -v $(pwd):/data $IMAGETAG -i /data/$i -o /data/$i.pdf; done
 for i in $(ls $INPUT_DATA/*.mmd); do cat $i | docker run -i -v $(pwd):/data $IMAGETAG -o /data/$i-stdin.pdf; done
+
+# Test if mmdc crashes on Markdown files containing no mermaid charts
+OUTPUT=$(docker run -v $(pwd):/data $IMAGETAG -i /data/test-positive/no-charts.md)
+EXPECTED_OUTPUT="No mermaid charts found in Markdown input"
+[[ "$OUTPUT" == "$EXPECTED_OUTPUT" ]] || echo "Expected output to be '$EXPECTED_OUTPUT', got '$OUTPUT'"


### PR DESCRIPTION
## :bookmark_tabs: Summary

Add an automated test for #165 

Resolves #166 

## :straight_ruler: Design Decisions

I simply run mmdc in a container, verify it doesn't crash and then compare its output to an expected value.
I'm not quite happy with this setup, as run_tests.sh is meant to be called with either test-positive or test-negative - this new test will run in both cases. I'd suggest removing the INPUT_DATA argument and hard-coding test-positive and test-negative.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
