### PR TITLE
Add optional CR to markdown graph detection regex.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test-positive/crlf-detect.md  eol=crlf

--- a/src/index.js
+++ b/src/index.js
@@ -203,7 +203,7 @@ const parseMMD = async (browser, definition, output) => {
   const browser = await puppeteer.launch(puppeteerConfig)
   const definition = await getInputData(input)
   if (/\.md$/.test(input)) {
-    const matches = definition.match(/^```(?:mermaid)(\n([\s\S]*?))```$/gm);
+    const matches = definition.match(/^```(?:mermaid)(\r?\n([\s\S]*?))```$/gm);
 
     if (matches !== null) {
       info(`Found ${matches.length} mermaid charts in Markdown input`);

--- a/test-positive/crlf-detect.md
+++ b/test-positive/crlf-detect.md
@@ -1,0 +1,4 @@
+```mermaid
+flowchart LR
+    test-->diagram
+```


### PR DESCRIPTION
## :bookmark_tabs: Summary
Add optional CR to markdown graph detection regex.
Add test CRLF markdown file.
Add .gitattributes to prevent git from converting CRLF to LF in test file.

Resolves #183 
