### PR TITLE
feat(md output): allow *.md files in output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ fontawesome/
 .DS_Store
 .npmrc
 yarn-error.log
+test-positive/*.out.md

--- a/README.md
+++ b/README.md
@@ -21,6 +21,40 @@ mmdc -i input.mmd -o output.svg
 mmdc -i input.mmd -o output.png -t dark -b transparent
 ```
 
+### Transform a markdown file with mermaid diagrams
+
+```sh
+mmdc -i readme.template.md -o readme.md
+```
+
+This command transforms a markdown file itself. The mermaid-cli will find the mermaid diagrams, create SVG files from them and refer to those in the markdown output.
+
+This:
+
+~~~md
+### Some markdown
+```mermaid
+graph
+   [....]
+```
+
+### Some more markdown
+```mermaid
+sequenceDiagram
+   [....]
+```
+~~~
+
+Becomes:
+
+```md
+### Some markdown
+![diagram](./readme-1.svg)
+
+### Some more markdown
+![diagram](./readme-2.svg)
+```
+
 ### Piping from stdin
 
 You can easily pipe input from stdin. This example shows how to use a heredoc to

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ commander
   .option('-w, --width [width]', 'Width of the page. Optional. Default: 800', /^\d+$/, '800')
   .option('-H, --height [height]', 'Height of the page. Optional. Default: 600', /^\d+$/, '600')
   .option('-i, --input <input>', 'Input mermaid file. Files ending in .md will be treated as Markdown and all charts (e.g. ```mermaid (...)```) will be extracted and generated. Required.')
-  .option('-o, --output [output]', 'Output file. It should be either svg, png or pdf. Optional. Default: input + ".svg"')
+  .option('-o, --output [output]', 'Output file. It should be either md, svg, png or pdf. Optional. Default: input + ".svg"')
   .option('-b, --backgroundColor [backgroundColor]', 'Background color. Example: transparent, red, \'#F0F0F0\'. Optional. Default: white')
   .option('-c, --configFile [configFile]', 'JSON configuration file for mermaid. Optional')
   .option('-C, --cssFile [cssFile]', 'CSS file for the page. Optional')
@@ -94,8 +94,8 @@ if (!output) {
   // specified with the '-o' option
   output = input ? (input + '.svg') : 'out.svg'
 }
-if (!/\.(?:svg|png|pdf)$/.test(output)) {
-  error(`Output file must end with ".svg", ".png" or ".pdf"`)
+if (!/\.(?:svg|png|pdf|md)$/.test(output)) {
+  error(`Output file must end with ".md", ".svg", ".png" or ".pdf"`)
 }
 const outputDir = path.dirname(output)
 if (!fs.existsSync(outputDir)) {
@@ -201,23 +201,41 @@ const parseMMD = async (browser, definition, output) => {
 
 (async () => {
   const mermaidChartsInMarkdown = '^```(?:mermaid)(\r?\n([\\s\\S]*?))```$';
-  const mermaidChartsInMarkdownReg = new RegExp(mermaidChartsInMarkdown, 'gm')
+  const mermaidChartsInMarkdownRegexGlobal = new RegExp(mermaidChartsInMarkdown, 'gm')
+  const mermaidChartsInMarkdownRegex = new RegExp(mermaidChartsInMarkdown)
   const browser = await puppeteer.launch(puppeteerConfig)
   const definition = await getInputData(input)
   if (/\.md$/.test(input)) {
-    const matches = definition.match(mermaidChartsInMarkdownReg);
 
-    if (matches !== null) {
-      info(`Found ${matches.length} mermaid charts in Markdown input`);
-      const mmdStrings = matches.map((str) => str.replace(mermaidChartsInMarkdownReg, '$1').trim());
-      await Promise.all(mmdStrings.map((mmdString, index) => {
-          const output_file = output.replace(/(\..*)$/,`-${index + 1}$1`);
-          info(` - ${output_file}`);
-          return parseMMD(browser, mmdString, output_file);
+    const diagrams = [];
+    const outDefinition = definition.replaceAll(mermaidChartsInMarkdownRegexGlobal, (mermaidMd) => {
+      const md = mermaidChartsInMarkdownRegex.exec(mermaidMd)[1];
+
+      // Output can be either a template image file, or a `.md` output file.
+      //   If it is a template image file, use that to created numbered diagrams
+      //     I.e. if "out.png", use "out-1.png", "out-2.png", etc
+      //   If it is an output `.md` file, use that to base .svg numbered diagrams on
+      //     I.e. if "out.md". use "out-1.svg", "out-2.svg", etc
+      const outputFile = output.replace(/(\..*)$/,`-${diagrams.length + 1}$1`).replace(/(\.md)$/, '.svg');
+      const outputFileRelative = `./${path.relative(path.dirname(path.resolve(output)), path.resolve(outputFile))}`;
+      diagrams.push([outputFile, md]);
+      return `![diagram](${outputFileRelative})`;
+    });
+
+    if (diagrams.length) {
+      info(`Found ${diagrams.length} mermaid charts in Markdown input`);
+      await Promise.all(diagrams.map(async ([imgFile, md]) => {
+          await parseMMD(browser, md, imgFile);
+          info(` ✅ ${imgFile}`);
         })
       );
     } else {
       info(`No mermaid charts found in Markdown input`);
+    }
+
+    if(/\.md$/.test(output)) {
+      await fs.promises.writeFile(output, outDefinition, 'utf-8');
+      info(` ✅ ${output}`);
     }
   } else {
     info(`Generating single mermaid chart`);

--- a/test-positive/markdown-output.md
+++ b/test-positive/markdown-output.md
@@ -1,0 +1,82 @@
+# Blackjack
+
+## Class diagram
+
+```mermaid
+ classDiagram
+      Card "*" --> "1" Suit
+      Card "*" --> "1" Rank
+      Player "1" --> "*" Card
+      Deck "1" --> "1" Random
+      Deck "1" --> "52" Card
+      Player "1" --> "1" Inquirer
+      Player "1" --> "1" Deck
+      Casino "1" --> "*" Player
+      Casino "1" --> "1" Deck
+      class Casino {
+          + void main(String[] args)
+          + void playBlackjack()
+      }
+      class Suit {
+       <<enumeration>>
+      }
+      class Rank {
+       <<enumeration>>
+       + int value()
+       }
+      class Inquirer {
+          String ask(String question, List<String> choices)
+          BigDecimal askNumber(String question, BigDecimal min, BigDecimal max);
+      }
+      class Random {
+          int nextInt(int bound)
+      }
+      class Player {
+          - double bet
+          - List<Card> hand;
+          + void makeBet()
+          + void play()
+          + void drawHand()
+      }
+      class Deck {
+          - Cards[] cards
+          + Card dealCard();
+          + void shuffle();
+      }
+      class Card {
+          +Suit suit()
+          +Rank rank()
+          +int value()
+          +boolean isAce()
+          +string toString()
+      }
+```
+
+## Sequence diagram
+
+```mermaid
+sequenceDiagram
+    actor User
+    User->>+Casino: playBlackjack()
+    Casino->>Casino: Create Random, Inquirer, Deck and Player
+    Casino->>+Deck: shuffleCards()
+    Deck->>Random: Use random when shuffling
+    Deck-->>-Casino: return
+    Casino->>+Player: drawHand()
+    Player->>+Deck: dealCard()
+    Deck-->>-Player: Card
+    Player->>+Deck: dealCard()
+    Deck-->>-Player: Card
+    Player-->>-Casino: return
+    Casino->>+Player: play()
+    loop While not busted
+      Player->>+Inquirer: ask("Hit or stand?")
+      alt hit
+      Inquirer-->>-Player: answer
+      Player->>+Deck: dealCard()
+      Deck-->>-Player: Card
+      end
+    end
+    Player-->>-Casino: return
+    Casino-->>-Joost: return
+```


### PR DESCRIPTION
## :bookmark_tabs: Summary

Allow a *.md file as output (provided with `-o`).

Resolves #154

## :straight_ruler: Design Decisions

It only works when the input is a *.md file as well. It will replace all mermaid-js diagrams in a markdown files with images.

This:

~~~md
### Some markdown
```mermaid
graph
   [....]
```
~~~

Becomes:

```md
### Some markdown
![diagram](./foo-1.svg)
```

It currently uses the output file name to base the image file names on. I.e. if "out.md". use "out-1.svg", "out-2.svg", etc. We can add support for other output file formats later by adding command line arguments. I was thinking about something like `--outputImage` for example.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
