### PR TITLE
Replace replaceAll with replace for node 14 support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -208,7 +208,7 @@ const parseMMD = async (browser, definition, output) => {
   if (/\.md$/.test(input)) {
 
     const diagrams = [];
-    const outDefinition = definition.replaceAll(mermaidChartsInMarkdownRegexGlobal, (mermaidMd) => {
+    const outDefinition = definition.replace(mermaidChartsInMarkdownRegexGlobal, (mermaidMd) => {
       const md = mermaidChartsInMarkdownRegex.exec(mermaidMd)[1];
 
       // Output can be either a template image file, or a `.md` output file.


### PR DESCRIPTION
## :bookmark_tabs: Summary

replaceAll is supported in nodejs >= 15. replace is supported since node 0.10.0 and does the same thing, except that it does not enforce that you use the regex global flag.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll#browser_compatibility
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#browser_compatibility

## :straight_ruler: Design Decisions

Allow more global compatibility.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
