### PR TITLE
Add background color style to output svg's

### DIFF
--- a/src-test/test.js
+++ b/src-test/test.js
@@ -41,7 +41,9 @@ async function compileDiagram(file, format) {
       "-o",
       out + "/" + result,
       "-c",
-      workflows + "/config.json"
+      workflows + "/config.json",
+      "-b",
+      "lightgray"
     ], { timeout: 5000 });
 
     const stdout = child.stdout.toString('utf8').trim()

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,10 @@ const error = message => {
   process.exit(1)
 }
 
+const warn = message => {
+  console.log(chalk.yellow(`\n${message}\n`))
+}
+
 const checkConfigFile = file => {
   if (!fs.existsSync(file)) {
     error(`Configuration file "${file}" doesn't exist`)
@@ -167,7 +171,15 @@ const parseMMD = async (browser, definition, output) => {
   }
 
   if (output.endsWith('svg')) {
-    const svg = await page.$eval('#container', container => container.innerHTML)
+    const svg = await page.$eval('#container', (container, backgroundColor) => {
+      const svg = container.getElementsByTagName?.('svg')?.[0]
+      if (svg.style) {
+        svg.style.backgroundColor = backgroundColor
+      } else {
+        warn("svg not found. Not applying background color.")
+      }
+      return container.innerHTML
+    }, backgroundColor)
     const svg_xml = convertToValidXML(svg)
     fs.writeFileSync(output, svg_xml)
   } else if (output.endsWith('png')) {


### PR DESCRIPTION
## :bookmark_tabs: Summary

Output svg's have a transparent background which doesn't look good against github's dark mode themed pages. Set the background-color in the style tag of the svg to set the background color to white (default) or whatever a user chooses with the -b option.

Resolves some user requests in this ticket: https://github.com/mermaid-js/mermaid/issues/1553

## :straight_ruler: Design Decisions

Shouldn't crash. Tests pass.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
