### PR TITLE
Fix the docker image paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,19 @@ mmdc -h
 ## Use Docker:
 
 ```sh
+docker pull minlag/mermaid-cli
+```
+
+or pull from Github Container Registry
+
+```sh 
 docker pull ghcr.io/mermaid-js/mermaid-cli/mermaid-cli
 ```
 
 or e.g. version 8.8.0
 
 ```sh
-docker pull ghcr.io/mermaid-js/mermaid-cli/mermaid-cli:8.8.0
+docker pull minlag/mermaid-cli:8.8.0
 ```
 
 The container looks for input files in `/data`. So for example, if you have a

--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ mmdc -h
 ## Use Docker:
 
 ```sh
-docker pull minlag/mermaid-cli
+docker pull ghcr.io/mermaid-js/mermaid-cli/mermaid-cli
 ```
 
 or e.g. version 8.8.0
 
 ```sh
-docker pull minlag/mermaid-cli:8.8.0
+docker pull ghcr.io/mermaid-js/mermaid-cli/mermaid-cli:8.8.0
 ```
 
 The container looks for input files in `/data`. So for example, if you have a


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fix the docker image paths in README

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
