### PR TITLE
Exit with exitcode = 1 on promise rejection

### DIFF
--- a/src-test/test.js
+++ b/src-test/test.js
@@ -148,12 +148,29 @@ async function compileAllStdin() {
   })
 }
 
+async function shouldErrorOnFailure() {
+  await compileDiagram("sequence.mmd", "svg"); // should work with default puppeteerConfigFile
+  try {
+    await compileDiagram("sequence.mmd", "svg", {puppeteerConfigFile: "../test-negative/puppeteerTimeoutConfig.json"});
+  } catch (error) {
+    console.log(`compiling with invalid puppeteerConfigFile file produced an error, which is well`);
+    return;
+  }
+  throw new Error(`Expected compling invalid puppeteerConfigFile file to fail, but it succeeded`);
+}
+
 module.exports = {
+  shouldErrorOnFailure,
   compileAll,
   compileAllStdin
 };
 
 if (require.main === module) {
+  shouldErrorOnFailure().catch(err => {
+    console.warn("Compilation failed", err)
+    process.exit(1);
+  });
+
   compileAll().catch(err => {
     console.warn("Compilation failed", err)
     process.exit(1);

--- a/src-test/test.js
+++ b/src-test/test.js
@@ -38,6 +38,7 @@ async function compileDiagramFromStdin(file, format) {
  * @param {Object} [options] - Optional options.
  * @param {string} [options.puppeteerConfigFile] - If set, puppeteerConfigFile.
  * Must be relative to workflow folder.
+ * @throws {Error} if mmdc fails to launch, or if it has exitCode != 0
  */
 async function compileDiagram(file, format, {puppeteerConfigFile} = {}) {
   return new Promise(async function(resolve, reject) {
@@ -73,9 +74,7 @@ async function compileDiagram(file, format, {puppeteerConfigFile} = {}) {
     }
 
     if (child.status !== 0 || child.error) {
-      // eslint-disable-next-line no-console
-      console.warn(`${file}: child process exited with code ${child.status}, error ${child.error}`);
-      reject(child.status);
+      reject(new Error(`${file}: child process exited with code ${child.status}, error ${child.error}`));
     } else {
       resolve(child.status);
     }

--- a/src/index.js
+++ b/src/index.js
@@ -254,4 +254,4 @@ const parseMMD = async (browser, definition, output) => {
     await parseMMD(browser, definition, output);
   }
   await browser.close()
-})()
+})().catch((exception) => error(exception instanceof Error ? exception.stack: exception))

--- a/test-negative/puppeteerTimeoutConfig.json
+++ b/test-negative/puppeteerTimeoutConfig.json
@@ -1,0 +1,4 @@
+{
+    "//comment": "setting a timeout of 1ms means puppeteer should always fail",
+    "timeout": 1
+}


### PR DESCRIPTION
## :bookmark_tabs: Summary

Currently, some errors in `mermaid-cli` cause an `UnhandledPromiseRejectionWarning`, and `mermaid-cli` then exits with `exitcode 0` instead of `exitcode 1`.

For example, if `puppeteer.launch` fails for any reason, there's nothing `.catch()`-ing the Promise rejection https://github.com/mermaid-js/mermaid-cli/blob/6fa464418488ead911faa2537ed4e2c33fc267f1/src/index.js#L218 are not caught anywhere.

I've added a `.catch()` block that logs the error (hiding the `UnhandledPromiseRejectionWarning`), then calls `process.exit(1)` to set the exitcode to 1.

## :straight_ruler: Design Decisions

I've added a test that sets puppeteer's launch timeout to 1ms, which should always cause an error. Before my PR, this causes `mmdc` to return with `exitcode == 0` (success) instead of returning with `exitcode == 1` (error).

Alternatively, you can also test by running the following command in your bash console:

#### Before

```console
me@me:~/Documents/mermaid-cli$ echo '{"timeout": 1}' > testPuppeteerConfig.json && node ./index.bundle.js -p testPuppeteerConfig.json -i test-positive/emojis.mmd; echo "exitcode was $?"
(node:2334257) UnhandledPromiseRejectionWarning: TimeoutError: Timed out after 1 ms while trying to connect to the browser! Only Chrome at revision r1002410 is guaranteed to work.
    at Timeout.onTimeout (/home/me/Documents/mermaid-cli/node_modules/puppeteer/lib/cjs/puppeteer/node/BrowserRunner.js:258:20)
    at listOnTimeout (internal/timers.js:557:17)
    at processTimers (internal/timers.js:500:7)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:2334257) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:2334257) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
exitcode was 0
```

#### After

```console
me@me:~/Documents/mermaid-cli$ echo '{"timeout": 1}' > testPuppeteerConfig.json && node ./index.bundle.js -p testPuppeteerConfig.json -i test-positive/emojis.mmd; echo "exitcode was $?"

TimeoutError: Timed out after 1 ms while trying to connect to the browser! Only Chrome at revision r1002410 is guaranteed to work.
    at Timeout.onTimeout (/home/me/Documents/mermaid-cli/node_modules/puppeteer/lib/cjs/puppeteer/node/BrowserRunner.js:258:20)
    at listOnTimeout (internal/timers.js:557:17)
    at processTimers (internal/timers.js:500:7)

exitcode was 1
```

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
  - ~By the way, I don't think `npm test` is auto-linting my code. Is it worth me copying over the lint config from https://github.com/mermaid-js/mermaid?~ `npm test` linting is added in #313
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
