### PR TITLE
Lint using `standard`

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -28,11 +28,9 @@ jobs:
         run: npm i yarn --global
 
       - name: Build the package
-        run: |
-          yarn
-          chmod 755 copy_modules.sh
-          ./copy_modules.sh
-
+        # throws an error if yarn.lock is out-of-date
+        # `yarn install` automatically builds the package
+        run: yarn install --frozen-lockfile
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.9.13
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,5 @@ jobs:
           cache: 'yarn'
       # throws an error if yarn.lock is out-of-date
       - run: yarn install --frozen-lockfile
-      - run: |
-          bash copy_modules.sh
       # runs jest unittests
       - run: yarn test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Please note that this project is released with a [Contributor Code of Conduct][c
 ## Submitting a pull request
 
 1. [Fork][fork] and clone the repository
-1. Configure and install the dependencies: `yarn install; source copy_modules.sh`
+1. Configure and install the dependencies: `yarn install`
 1. Create a new branch: `git checkout -b my-branch-name`. Make sure to give a good name to the branch. New features shall start with `feature/<branch name>`. Bug fixes shall start with `fix/<branch-name>`
 1. Make your change, add tests, and make sure the tests still pass
 1. Push to your fork and [submit a pull request][pr]
@@ -20,7 +20,8 @@ Please note that this project is released with a [Contributor Code of Conduct][c
 
 Here are a few things you can do that will increase the likelihood of your pull request is accepted:
 
-- Follow the [style guide][style] which is using standard. Any linting errors should be shown when running `npm test`
+- Follow the [style guide][style] which is using [standard][style]. Any linting errors should be shown when running `npm test`.
+    - Some linting errors might be automatically fixed by `yarn run lint-fix`.
 - Write and update tests.
 - Keep your change as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, submit them as separate pull requests.
 - Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).

--- a/DockerfileBuild
+++ b/DockerfileBuild
@@ -10,8 +10,6 @@ WORKDIR /app
 COPY . /app/
 
 RUN yarn \
-    && chmod 755 copy_modules.sh \
-    && /bin/sh copy_modules.sh \
     && yarn pack
 
 FROM node:alpine AS mermaid-cli-current

--- a/building.md
+++ b/building.md
@@ -18,9 +18,7 @@ Instead of creating a .npmrc file on your own you can also use npm login --regis
 yarn
 ```
 
-2. Run the bash script copy_modules.sh
-
-3. Run the script like below:
+2. Run the script like below:
 
 ```sh
 node src/cli.js -i test/state1.mmd

--- a/copy_modules.sh
+++ b/copy_modules.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 cp ./node_modules/mermaid/dist/mermaid.min.js .
 
 mkdir -p fontawesome/css/

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Install chromium and required fonts
 # available fonts https://wiki.alpinelinux.org/wiki/Fonts

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   },
   "exports": "./src/index.js",
   "scripts": {
-    "upgrade": "yarn-upgrade-all && bash copy_modules.sh",
-    "prepare": "bash copy_modules.sh",
-    "prepack": "bash copy_modules.sh",
+    "upgrade": "yarn-upgrade-all && sh copy_modules.sh",
+    "prepare": "sh copy_modules.sh",
+    "prepack": "sh copy_modules.sh",
     "test": "standard && yarn node --experimental-vm-modules $(yarn bin jest)",
     "lint": "standard",
     "lint-fix": "standard --fix"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   },
   "exports": "./src/index.js",
   "scripts": {
-    "upgrade": "yarn-upgrade-all && source copy_modules.sh",
+    "upgrade": "yarn-upgrade-all && bash copy_modules.sh",
+    "prepare": "bash copy_modules.sh",
+    "prepack": "bash copy_modules.sh",
     "test": "standard && yarn node --experimental-vm-modules $(yarn bin jest)",
     "lint": "standard",
     "lint-fix": "standard --fix"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
   "exports": "./src/index.js",
   "scripts": {
     "upgrade": "yarn-upgrade-all && source copy_modules.sh",
-    "test": "yarn node --experimental-vm-modules $(yarn bin jest)"
+    "test": "standard && yarn node --experimental-vm-modules $(yarn bin jest)",
+    "lint": "standard",
+    "lint-fix": "standard --fix"
   },
   "dependencies": {
     "chalk": "^5.0.1",
@@ -39,5 +41,10 @@
     "moduleNameMapper": {
       "#(.*)": "<rootDir>/node_modules/$1"
     }
+  },
+  "standard": {
+    "ignore": [
+      "mermaid.min.js"
+    ]
   }
 }

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 INPUT_DATA=$1
 IMAGETAG=$2
 
@@ -19,7 +19,7 @@ cat $INPUT_DATA/flowchart1.mmd | docker run --rm -i -v $(pwd):/data $IMAGETAG -o
 # Test if mmdc crashes on Markdown files containing no mermaid charts
 OUTPUT=$(docker run --rm -v $(pwd):/data $IMAGETAG -i /data/test-positive/no-charts.md)
 EXPECTED_OUTPUT="No mermaid charts found in Markdown input"
-[[ "$OUTPUT" == "$EXPECTED_OUTPUT" ]] || echo "Expected output to be '$EXPECTED_OUTPUT', got '$OUTPUT'"
+[ "$OUTPUT" = "$EXPECTED_OUTPUT" ] || echo "Expected output to be '$EXPECTED_OUTPUT', got '$OUTPUT'"
 
 # Test if mmdc does not replace <br> with <br/>
 docker run --rm -v $(pwd):/data $IMAGETAG -i /data/test-positive/graph-with-br.mmd -w 800;


### PR DESCRIPTION
## :bookmark_tabs: Summary

Lints this project using [`standard`](https://standardjs.com/).

I've added running `standard` to the `package.json#scripts#test` (in https://github.com/mermaid-js/mermaid-cli/pull/313/commits/b1fda2004618e7c358787a058b843bd902ff33da), since that's what it says in `CONTRIBUTING.md`:

https://github.com/mermaid-js/mermaid-cli/blob/6fa464418488ead911faa2537ed4e2c33fc267f1/CONTRIBUTING.md?plain=1#L23

~I've also added a GitHub Actions CI action that runs `yarn test` automatically for future PRs in https://github.com/mermaid-js/mermaid-cli/commit/34017714315dd1577e16610e1669aab7e7b0d228.~ Already added by https://github.com/mermaid-js/mermaid-cli/commit/9c15b9d8cded5430e934cb9b90a8bdad83cb32d8 in `master`.

~Finally, I've fixed any errors that were NOT automatically fixed by `standard --fix` in https://github.com/mermaid-js/mermaid-cli/commit/e77b3c92a0b59d5cc4adb975441925c75081af40.~ Already fixed by https://github.com/mermaid-js/mermaid-cli/commit/9ae5cb24524279ae05390018bfcaa4e115f46d26 on `master.

I haven't run `standard --fix`, so that the `git diff` is smaller and to make this PR easier to review/less likely to cause merge conflicts. **Linting errors should be fixed by running `standard --fix` right before/after merging** (example: https://github.com/aloisklink/mermaid-cli/commit/14efaa70f8c3c97cdd8cdaa4784538771be830d2).

## :straight_ruler: Design Decisions

To simplify the `.github/workflows/lint.yml` file, I've moved the `prepublishOnly` script into a `prepare` and `prepack` script, as `npm`/`yarn` will call those scripts automatically, when needed (https://github.com/mermaid-js/mermaid-cli/pull/313/commits/79bf0b295aeb7f97399f51cba86597fa9a0bc623).

[`npm run prepare`](https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts) is recommended for building NPM packages, as it's called automatically before `npm pack`, `npm publish`, and `npm install .` (local) or `npm install git+https://` (git dependency).

[`yarn run prepack`](https://yarnpkg.com/advanced/lifecycle-scripts) is recommended for building yarn packages, as it's called before `yarn pack`, `yarn publish`, and automatically when installing from "raw" sources, like a git dependency.

I've also modified all the `*.sh` scripts to have a `!/bin/sh` shebang, since the Alpine Linux Docker image doesn't actually support bash. Only `run-tests.sh` required a very minor change to be `/bin/sh` compliant (https://github.com/mermaid-js/mermaid-cli/pull/313/commits/1c73419f333f6e1c161f06344becf145d35706f6).

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
    - Auto-fixable linting issues have **not** been fixed, to make the `git diff` easier to review. Please run `yarn run lint-fix` right before/after merging.
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
