### PR TITLE
Throw error if mermaid rendering fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ fontawesome/
 .npmrc
 yarn-error.log
 test-positive/*.out.md
+test-output/
+

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "chalk": "^4.1.0",
     "commander": "^9.0.0",
-    "mermaid": "^9.0.0",
+    "mermaid": "^9.1.2",
     "puppeteer": "^14.1.0"
   },
   "devDependencies": {

--- a/src-test/test.js
+++ b/src-test/test.js
@@ -131,8 +131,10 @@ async function compileAllStdin() {
     fs.readdir(workflows, async (err, files) => {
       resolve(Promise.all(
         files.map(async file => {
-          if (!(file.endsWith(".mmd") | /\.md$/.test(file))) {
-            return Promise.resolve();
+          // currently, piping markdown through stdin is not supported
+          // as mermaid-cli has no idea it's markdown, not mermaid code
+          if (!(file.endsWith(".mmd"))) {
+            return `Skipping ${file}, as it does not end with .mmd`;
           }
           const expectError = /expect-error/.test(file);
           const resultP = compileDiagramFromStdin(file, "svg")

--- a/src-test/test.js
+++ b/src-test/test.js
@@ -19,7 +19,9 @@ async function compileDiagramFromStdin(file, format) {
       // eslint-disable-next-line no-console
       console.warn(`Compiling ${file} into ${result}`);
       execSync(`cat ${workflows}/${file} | \
-        node index.bundle.js -o ${out}/${result} -c ${workflows}/config.json`);
+        node index.bundle.js -o ${out}/${result} -c ${workflows}/config.json`, {
+          "encoding": "utf8", // execSync has buffer as default, unlike exec
+        });
 
       resolve();
     } catch (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -160,7 +160,7 @@ const parseMMD = async (browser, definition, output) => {
     }
 
     try {
-      window.mermaid.init(undefined, container)
+      window.mermaid.initThrowsErrors(undefined, container)
       return { status: 'success' };
     } catch (error) {
       return { status: 'error', error, message: error.message };

--- a/src/index.js
+++ b/src/index.js
@@ -180,8 +180,8 @@ const parseMMD = async (browser, definition, output) => {
       }
       return container.innerHTML
     }, backgroundColor)
-    const svg_xml = convertToValidXML(svg)
-    fs.writeFileSync(output, svg_xml)
+    const svgXML = convertToValidXML(svg)
+    fs.writeFileSync(output, svgXML)
   } else if (output.endsWith('png')) {
     const clip = await page.$eval('svg', svg => {
       const react = svg.getBoundingClientRect()

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import puppeteer from 'puppeteer'
 import pkg from './package.json'
 
 const error = message => {
-  console.log(chalk.red(`\n${message}\n`))
+  console.error(chalk.red(`\n${message}\n`))
   process.exit(1)
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2863,7 +2863,7 @@ make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-mermaid@^9.0.0:
+mermaid@^9.1.2:
   version "9.1.2"
   resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-9.1.2.tgz#98cdc55603464240987fe1a15f68dd06304c07f1"
   integrity sha512-RVf3hBKqiMfyORHboCaEjOAK1TomLO50hYRPvlTrZCXlCniM5pRpe8UlkHBjjpaLtioZnbdYv/vEVj7iKnwkJQ==


### PR DESCRIPTION
## :bookmark_tabs: Summary

Throws an error if mermaid rendering fails. If there is an error:
  - mermaid-cli exits with exitcode 1.
  - The errors are logged to `stderr` (`console.error`).
  - **Changed Behaviour:** **If there is an error, there is no output file.** Previously there was an output file that said "Syntax error in graph: mermaid version 9.1.2" (e.g.: [mermaid-error.png](https://user-images.githubusercontent.com/19716675/175838572-7834ab91-c54a-4ea1-b508-b1fb1222d402.png))


Resolves #276, #245, #138, #109

Example:

```console
me@me:~/mermaid-cli$ node index.bundle.js -i test-negative/invalid.expect-error.mmd -o test-output/invalid.expect-error.svg -c test-positive/config.json
Generating single mermaid chart

Parse error on line 2:
...nceDiagram  Nothing:Valid
----------------------^
Expecting 'SOLID_OPEN_ARROW', 'DOTTED_OPEN_ARROW', 'SOLID_ARROW', 'DOTTED_ARROW', 'SOLID_CROSS', 'DOTTED_CROSS', 'SOLID_POINT', 'DOTTED_POINT', got 'TXT'
me@me:~/mermaid-cli$ echo $?
1
```

## :straight_ruler: Design Decisions

Uses the new `initThrowsError` from Mermaid that was added in https://github.com/mermaid-js/mermaid/pull/3052 by @MindaugasLaganeckas.

**Important**: I'm not sure whether to classify this as a feature or a fix.
Because this changes behaviour, maybe it is worth hiding this behind an option?
Or maybe we could add an option to use the old behaviour, something like `--ignore-errors`?

We should also add a warning to the release notes, e.g. something like

```markdown
**⚠️ mermaid-cli now throws an error if mermaid fails, instead of making a diagram containing "Syntax Error"**
```

To simplify the `src-test` code, I used `require("fs/promises");`, which is only supported in NodeJS 14+. I don't think this is a big deal, since it's only in the test code, but I can change it to `require("fs").promises` (NodeJS 10+). 

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
  - I tried to follow the old code style, e.g. I used `"string"` instead of `'string'` when the old code used `"`. The style errors can be fixed with `npx standard --fix` though.
- [x] :computer: have added unit/e2e tests (if appropriate)
  - The test code now runs on the `test-negative` folder too.
- [x] :bookmark: targeted `master` branch
