### PR TITLE
Exit with error exitcode on invalid input

### DIFF
--- a/src-test/test.js
+++ b/src-test/test.js
@@ -1,10 +1,11 @@
 "use strict";
 
 const fs = require("fs/promises");
-const { execSync, spawnSync } = require("child_process");
+const { execSync, spawnSync, execFile } = require("child_process");
 
 // Joins together directory/file names in a OS independent way
 const {join} = require("path");
+const {promisify} = require("util");
 
 const workflows = ["test-positive", "test-negative"];
 const out = "test-output";
@@ -161,13 +162,29 @@ async function shouldErrorOnFailure() {
   throw new Error(`Expected compling invalid puppeteerConfigFile file to fail, but it succeeded`);
 }
 
+async function shouldErrorOnEmptyInput() {
+  try {
+    await promisify(execFile)('node', ['index.bundle.js'])
+  } catch (error) {
+    console.log(`✅compiling with no input produced an error, which is well`)
+    return
+  }
+  throw new Error('Expected compiling with no input to fail, but it succeeded')
+}
+
 module.exports = {
   shouldErrorOnFailure,
+  shouldErrorOnEmptyInput,
   compileAll,
   compileAllStdin
 };
 
 if (require.main === module) {
+  shouldErrorOnEmptyInput().catch(err => {
+    console.warn("Compilation failed", err)
+    process.exit(1);
+  });
+
   shouldErrorOnFailure().catch(err => {
     console.warn("Compilation failed", err)
     process.exit(1);

--- a/src/index.js
+++ b/src/index.js
@@ -83,9 +83,9 @@ let { theme, width, height, input, output, backgroundColor, configFile, cssFile,
 
 // check input file
 if (!(input || inputPipedFromStdin())) {
-  console.log(chalk.red(`\nPlease specify input file: -i <input>\n`))
-  commander.help()
-  process.exit(1)
+  console.error(chalk.red(`\nPlease specify input file: -i <input>\n`))
+  // Log to stderr, and return with error exitCode
+  commander.help({error: true})
 }
 if (input && !fs.existsSync(input)) {
   error(`Input file "${input}" doesn't exist`)


### PR DESCRIPTION
## :bookmark_tabs: Summary

Currently, if an input is not specified, `commander.help()` is called, which outputs the help text to stdout, and exits with `exitcode = 0`. The `process.exit(1)` line is never reached.

The `{error: true}` option can instead be used to output the help to stderr, and exit with an error exitcode, see: https://github.com/tj/commander.js#display-help-from-code

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
