### PR TITLE
Make mermaid a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "chalk": "^4.1.0",
     "commander": "^9.0.0",
-    "jest": "^28.1.2",
     "puppeteer": "^15.1.1"
   },
   "devDependencies": {
@@ -25,6 +24,7 @@
     "@babel/preset-env": "^7.0.0",
     "@fortawesome/fontawesome-free-webfonts": "^1.0.9",
     "mermaid": "^9.1.2",
+    "jest": "^28.1.2",
     "standard": "^17.0.0",
     "yarn-upgrade-all": "^0.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "chalk": "^4.1.0",
     "commander": "^9.0.0",
     "jest": "^28.1.2",
-    "mermaid": "^9.1.2",
     "puppeteer": "^15.1.1"
   },
   "devDependencies": {
@@ -25,6 +24,7 @@
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@fortawesome/fontawesome-free-webfonts": "^1.0.9",
+    "mermaid": "^9.1.2",
     "standard": "^17.0.0",
     "yarn-upgrade-all": "^0.7.0"
   },


### PR DESCRIPTION
## :bookmark_tabs: Summary

Makes mermaid a `devDependency` instead of `dependency`.

Mermaid is bundled already as `mermaid.min.js` when running `copy_modules.sh`, so there's no need to install it to run `mermaid-cli`.

## :straight_ruler: Design Decisions

I've also made `jest` (used for testing) a `devDependency` too in this PR, to avoid merge conflicts. My fault, I added it to the wrong place in #324!

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
