### PR TITLE
Support SVG/PDF template files for markdown input

### DIFF
--- a/src-test/test.js
+++ b/src-test/test.js
@@ -132,4 +132,18 @@ describe("mermaid-cli", () => {
       compileDiagram("test-negative", "invalid.expect-error.mmd", "svg")
     ).rejects.toThrow("Parse error on line 2");
   });
+
+  test('should write multiple SVGs for default .md input by default', async () => {
+    const expectedOutputFiles = [1, 2, 3].map((i) => join('test-positive', `mermaid.md-${i}.svg`))
+    // delete any files from previous test (fs.rm added in Node v14.14.0)
+    await Promise.all(expectedOutputFiles.map((file) => fs.rm(file, { force: true })))
+
+    await promisify(execFile)('node', ['src/index.js', '-i', 'test-positive/mermaid.md'])
+
+    // files should exist, and they should be SVGs
+    await Promise.all(expectedOutputFiles.map(async (file) => {
+      const svgFile = await fs.readFile(file, { encoding: 'utf8' })
+      expect(svgFile).toMatch(/^<svg/)
+    }))
+  })
 });

--- a/src/index.js
+++ b/src/index.js
@@ -236,7 +236,7 @@ const parseMMD = async (browser, definition, output) => {
       //     I.e. if "out.png", use "out-1.png", "out-2.png", etc
       //   If it is an output `.md` file, use that to base .svg numbered diagrams on
       //     I.e. if "out.md". use "out-1.svg", "out-2.svg", etc
-      const outputFile = output.replace(/(\.(md|png))$/,`-${diagrams.length + 1}$1`).replace(/(\.md)$/, '.svg');
+      const outputFile = output.replace(/(\.(md|png|svg|pdf))$/,`-${diagrams.length + 1}$1`).replace(/(\.md)$/, '.svg');
       const outputFileRelative = `./${path.relative(path.dirname(path.resolve(output)), path.resolve(outputFile))}`;
       diagrams.push([outputFile, md]);
       return `![diagram](${outputFileRelative})`;


### PR DESCRIPTION
~**Draft until #350 is merged, since I didn't want a merge conflict.** I'm leaving this here open for review since it fixes #348.~

## :bookmark_tabs: Summary

Currently, Mermaid only supports using png as a output when using markdown as an input, e.g. `-i markdown.md -o hi.png` will output:
`hi-1.png`, `hi-2.png`, ...

This PR adds support for `svg` and `pdf`.

This means that when running `-i markdown.md` with no `-o` output arg, the default `.svg` will be used to output
`markdown.md-1.svg`, `markdown.md-2.svg`, ...

**Resolves #348**

### Before

(All images have the same filename, so overwrite each other)
![image](https://user-images.githubusercontent.com/19716675/184510586-99427af4-06ee-4396-8748-9fec93353b8c.png)

### After

![image](https://user-images.githubusercontent.com/19716675/184510553-23583396-f11a-493b-9b42-95e77f3a8304.png)

## :straight_ruler: Design Decisions

The actual change is only one line: https://github.com/mermaid-js/mermaid-cli/commit/4dc31257e567102c6f1fd9c7187fee0588577a17

I've made this PR on top of #350 just to avoid a merge conflict in the test code.
If #350 doesn't get merged, we can always easily change this PR.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch