### PR TITLE
feat: add NodeJS API to mermaid-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,20 @@ the container to generate an SVG file as follows:
 docker run -it -v /path/to/diagrams:/data minlag/mermaid-cli -i /data/diagram.mmd
 ```
 
+## Use Node.JS API
+
+It's possible to call `mermaid-cli` via a Node.JS API.
+Please be aware that **the NodeJS API is not covered by semver**, as `mermaid-cli` follows
+`mermaid`'s versioning.
+
+```js
+import { run } from "@mermaid-js/mermaid-cli"
+
+await run(
+   "input.mmd", "output.svg", // {optional options},
+)
+```
+
 ## Install locally
 
 Some people are [having issues](https://github.com/mermaidjs/mermaid.cli/issues/15)

--- a/building.md
+++ b/building.md
@@ -23,5 +23,5 @@ yarn
 3. Run the script like below:
 
 ```sh
-node src/index.js -i test/state1.mmd
+node src/cli.js -i test/state1.mmd
 ```

--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
   "type": "module",
   "author": "Tyler Long <tyler4long@gmail.com>",
   "bin": {
-    "mmdc": "./src/index.js"
+    "mmdc": "./src/cli.js"
   },
   "engines": {
     "node": ">=14.1.0"
   },
+  "exports": "./src/index.js",
   "scripts": {
     "upgrade": "yarn-upgrade-all && source copy_modules.sh",
     "test": "jest"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "exports": "./src/index.js",
   "scripts": {
     "upgrade": "yarn-upgrade-all && source copy_modules.sh",
-    "test": "jest"
+    "test": "yarn node --experimental-vm-modules $(yarn bin jest)"
   },
   "dependencies": {
     "chalk": "^5.0.1",
@@ -34,5 +34,10 @@
     "mermaid.min.js",
     "index.html",
     "fontawesome/*"
-  ]
+  ],
+  "jest": {
+    "moduleNameMapper": {
+      "#(.*)": "<rootDir>/node_modules/$1"
+    }
+  }
 }

--- a/src-test/test.js
+++ b/src-test/test.js
@@ -27,7 +27,7 @@ async function compileDiagramFromStdin(workflow, file, format) {
   const result = file.replace(/\.(?:mmd|md)$/, "-stdin." + format);
   // exec will throw with stderr if there is a non-zero exit code
   return await promisify(exec)(`cat ${workflow}/${file} | \
-    node src/index.js -o ${out}/${result} -c ${workflow}/config.json`
+    node src/cli.js -o ${out}/${result} -c ${workflow}/config.json`
   );
 }
 
@@ -46,7 +46,7 @@ async function compileDiagram(workflow, file, format, {puppeteerConfigFile} = {}
     const result = file.replace(/\.(?:mmd|md)$/, "." + format);
 
     const args = [
-      "src/index.js",
+      "src/cli.js",
       "-i",
       join(workflow, file),
       "-o",
@@ -124,7 +124,7 @@ describe("mermaid-cli", () => {
   });
 
   test("should error on missing input", async() => {
-    await expect(promisify(execFile)('node', ['src/index.js'])).rejects.toThrow();
+    await expect(promisify(execFile)('node', ['src/cli.js'])).rejects.toThrow();
   });
 
   test("should error on mermaid syntax error", async() => {
@@ -138,7 +138,7 @@ describe("mermaid-cli", () => {
     // delete any files from previous test (fs.rm added in Node v14.14.0)
     await Promise.all(expectedOutputFiles.map((file) => fs.rm(file, { force: true })))
 
-    await promisify(execFile)('node', ['src/index.js', '-i', 'test-positive/mermaid.md'])
+    await promisify(execFile)('node', ['src/cli.js', '-i', 'test-positive/mermaid.md'])
 
     // files should exist, and they should be SVGs
     await Promise.all(expectedOutputFiles.map(async (file) => {

--- a/src-test/test.js
+++ b/src-test/test.js
@@ -1,16 +1,14 @@
-"use strict";
-
-const fs = require("fs/promises");
+import fs from 'fs/promises'
 // Can't use async to load workflow entries, see https://github.com/facebook/jest/issues/2235
-const {readdirSync} = require("fs");
-const { exec, execFile } = require("child_process");
+import { readdirSync } from 'fs'
+import { exec, execFile } from 'child_process'
 
 // Joins together directory/file names in a OS independent way
-const {join} = require("path");
-const {promisify} = require("util");
+import { join, relative } from 'path'
+import { promisify } from 'util'
 
 // optional (automatically added by jest), but useful to have for your code editor/autocomplete
-const { expect, beforeAll, describe, test } = require("@jest/globals");
+import { expect, beforeAll, describe, test } from '@jest/globals'
 
 const workflows = ["test-positive", "test-negative"];
 const out = "test-output";

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+import { cli, error } from './index.js'
+
+process.title = 'mmdc'
+cli().catch((exception) => error(exception instanceof Error ? exception.stack : exception))

--- a/src/index.js
+++ b/src/index.js
@@ -270,6 +270,8 @@ async function run (input, output, { puppeteerConfig = {}, quiet = false, parseM
   const mermaidChartsInMarkdownRegexGlobal = new RegExp(mermaidChartsInMarkdown, 'gm')
   const mermaidChartsInMarkdownRegex = new RegExp(mermaidChartsInMarkdown)
   const browser = await puppeteer.launch(puppeteerConfig)
+  try {
+  // TODO: indent this (currently unindented to make `git diff` smaller)
   const definition = await getInputData(input)
   if (/\.md$/.test(input)) {
 
@@ -309,7 +311,9 @@ async function run (input, output, { puppeteerConfig = {}, quiet = false, parseM
     const data = await parseMMD(browser, definition, path.extname(output).replace('.', ''), parseMMDOptions)
     await fs.promises.writeFile(output, data)
   }
-  await browser.close()
+  } finally {
+    await browser.close()
+  }
 }
 
 export { run, parseMMD, cli, error }

--- a/src/index.js
+++ b/src/index.js
@@ -225,7 +225,7 @@ async function parseMMD (browser, definition, outputFormat, { viewport, backgrou
       const react = svg.getBoundingClientRect()
       return { x: Math.floor(react.left), y: Math.floor(react.top), width: Math.ceil(react.width), height: Math.ceil(react.height) }
     })
-    await page.setViewport({ width: clip.x + clip.width, height: clip.y + clip.height, deviceScaleFactor: viewport.deviceScaleFactor })
+    await page.setViewport({...viewport, width: clip.x + clip.width, height: clip.y + clip.height})
     return await page.screenshot({ clip, omitBackground: backgroundColor === 'transparent' })
   } else { // pdf
     if (pdfFit) {


### PR DESCRIPTION
Sorry, one last PR for you to review @MindaugasLaganeckas!

## :bookmark_tabs: Summary

Instead of just using the mmdc CLI, this PR will make it possible to run mermaid-cli from a NodeJS API, e.g.

```js
import { run } from "@mermaid-js/mermaid-cli"
await run("input.mmd", "output.svg", /* {optional options} */)
```

**BREAKING CHANGE**: The CLI (mmdc) entry to this module is now `src/cli.js`. This shouldn't be a big deal, since it was already changed to `src/index.js` in #350.

## :straight_ruler: Design Decisions

This will make testing easier, and allow nodejs packages to call `mmdc` directly, which should simplify a lot of people's code, e.g. see:
  - https://github.com/mermaid-js/mermaid-cli/issues/271#issue-1186458762
  - https://github.com/mermaid-js/mermaid-cli/issues/247
  - https://github.com/mermaid-js/mermaid-cli/issues/154#issuecomment-989828463
  - My library [remark-mermaid-dataurl](https://github.com/aloisklink/remark-mermaid-dataurl)

### Downsides

I've just found when making this PR that you've already commented on this issue: https://github.com/mermaid-js/mermaid-cli/issues/247#issuecomment-1047489580

- New API means more features to maintain
  - Since the CLI run this code internally, we need these features anyway. I've just turned them into functions and made them public.
  - I made sure to state that the "NodeJS API is not covered by semver" in the README.md, we can change it whenever we want, since the CLI is the more important API.
  - You're also welcome to `@-me` (with `@aloisklink`) on any bug reports, and I'll try to make time to fix them.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
  - The new `cli()` function I added has the wrong indentation to make the PR review easier. If you want, I can either fix the indentation manually before merge. We could also run a `yarn standard --fix` to autofix indentation.
  - Additionally, some of `run()` has to wrong indentation too, to make PR review easier, since I moved some code into a `try... finally...`
- [x] :computer: have added unit/e2e tests (if appropriate)
  - ~Not added since `jest` only has experimental support for ESM currently: https://github.com/facebook/jest/issues/9430, but the CLI tests call this code.~ Added!
- [x] :bookmark: targeted `master` branch

_Edit:_ Rebased on `master` to fix failing tests due to 171f8b7e982d1f523a2aba41015dd95cb5be7546