### PR TITLE
ci: update percy upload action

### DIFF
--- a/.github/workflows/compile-mermaid.yml
+++ b/.github/workflows/compile-mermaid.yml
@@ -67,10 +67,10 @@ jobs:
           name: output
           path: ./${{env.INPUT_DATA}}
 
-      - name: Upload diagrams for automatic inspection
-        uses: MindaugasLaganeckas/percy-upload@v1.0.0
-        with:
-          inFolder: ${{env.INPUT_DATA}}
+      - name: Upload diagrams to percy for automatic inspection
+        # copied from https://docs.percy.io/docs/github-actions
+        # should automatically upload `.png`
+        run: npx @percy/cli upload "$INPUT_DATA"
 
       - name: Login to GitHub Container Registry
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
## :bookmark_tabs: Summary

Updates Percy to use the new SDK

Currently, Percy has a warning that says **Heads up! The SDK used in this build is deprecated and no longer supported. [You can find SDK instructions to upgrade your SDK here.](https://docs.percy.io/docs/migrating-to-percy-cli)**

![image](https://user-images.githubusercontent.com/19716675/185470694-57189138-849f-4f05-834a-922b005224e4.png)

Copied from https://docs.percy.io/docs/github-actions

## :straight_ruler: Design Decisions

I'm 95% sure this will work, but to test, it might be worth moving this branch into your repo, since the PERCY_TOKEN is private, and won't work on forks (like this PR).

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
