### PR TITLE
ci: fix percy ci action

### DIFF
--- a/.github/workflows/compile-mermaid.yml
+++ b/.github/workflows/compile-mermaid.yml
@@ -1,5 +1,5 @@
 name: "Build, test and deploy mermaid-cli Docker image"
-on: [push, pull_request_target]
+on: [push, pull_request]
 concurrency: ci-${{ github.ref }}
 jobs:
   build:

--- a/docs/reviewing.md
+++ b/docs/reviewing.md
@@ -1,0 +1,23 @@
+# Reviewing a PR
+
+## Running Percy Visual Inspection tests from a PR from a fork
+
+In order to run Percy visual inspection tests, a PR from a fork may have to
+be brought into the main repo.
+
+This is because uploading to Percy requires a GitHub Secret token, which cannot
+be accessed from forks for security reasons.
+
+After you have reviewed the work, and made sure there is no security exploit
+(e.g. no `echo "$TOKEN"`), then you can run the following to get percy working:
+
+```bash
+git switch -c "<NAME_OF_YOUR_BRANCH>"
+git pull "https://github.com/<NAME_OF_YOUR_USERNAME>/mermaid-cli.git" "<NAME_OF_YOUR_BRANCH>"
+# Make sure the commit hash matches the commit hash of the PR you reviewed
+git log --max-count=1
+git push git@github.com:mermaid-js/mermaid-cli.git "<NAME_OF_YOUR_BRANCH>"
+```
+
+After pushing, CI should re-run on that commit, and Percy should show up on the
+PR after a few minutes, **as long as both branchs have the same commit hash**.


### PR DESCRIPTION
## :bookmark_tabs: Summary

The `pull_request_target` event does have access to the repository secrets, but this is because it doesn't run on the fork contents.

Instead, it runs on the target of the PR, e.g. when somebody makes a PR, instead of testing/running on their fork's `feature/...` branch, it runs on `mermaid-cli`'s `master` branch, which hasn't been changed.

Unfortunately, **there's no easy way to give forks access to our GitHub Actions secrets,** because if there was, they could just do `"echo "$MY_SECRET"` and they'll see the secret.

Instead, there are three things we can do:
  - :heavy_check_mark: (what I documented in this PR)
    Manually make a copy of the fork branch in this repo (after reviewing first so there are no security issues)
  - :question: Make `PERCY_TOKEN` public.
    I'm not 100% sure this is safe (somebody could probably use this to mine cryptocurrency on Percy servers).
    However, this is what chromatic (a similar visual inspection software) recommends
    https://www.chromatic.com/docs/github-actions#forked-repositories
  - :question: We could move to something like: https://github.com/americanexpress/jest-image-snapshot. However, since it stores the snapshots in the git repo (instead of an external server like Percy), it makes the git repo get larger very quickly, so it's not great for big projects.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
