### PR TITLE
ci: fix percy CI upload from forks

### DIFF
--- a/.github/workflows/compile-mermaid.yml
+++ b/.github/workflows/compile-mermaid.yml
@@ -11,7 +11,6 @@ jobs:
       IMAGENAME: mermaid-cli
       DOCKER_IO_REPOSITORY: minlag/mermaid-cli
       INPUT_DATA: test-positive
-      PERCY_TOKEN: ${{secrets.PERCY_TOKEN}}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -68,15 +67,20 @@ jobs:
           npx --yes convert-svg-to-png@0.5.0 "${svg_files_to_convert[@]}"
 
       - name: Upload diagrams for manual inspection
+        # also uploads for `upload-percy.yml` action
         uses: actions/upload-artifact@v3
         with:
           name: output
           path: ./${{env.INPUT_DATA}}
-
       - name: Upload diagrams to percy for automatic inspection
+        # only run on push
+        # For PRs, the ./upload-percy.yml file is used instead
+        if: github.event_name == 'push'
         # copied from https://docs.percy.io/docs/github-actions
         # should automatically upload `.png`
         run: npx @percy/cli upload "$INPUT_DATA"
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 
       - name: Login to GitHub Container Registry
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/upload-percy.yml
+++ b/.github/workflows/upload-percy.yml
@@ -1,0 +1,70 @@
+# Uploads created PR artifacts to percy
+#
+# Uploading to percy requires access to our secret PERCY_TOKEN environment
+# variable.
+# However, PRs from forks do not normally have access to GitHub Actions secrets
+# as otherwise, they could just add an `echo "TOKEN"` to their PR to view the secret.
+#
+# Instead, we create a separate workflow_run action that runs after PRs without
+# looking at any PR code, that then uploads to percy.
+# This follows GitHub's recommended security guide,
+# see https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+name: Upload to Percy
+
+on:
+  workflow_run:
+    workflows: ["Build, test and deploy mermaid-cli Docker image"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      # disable unused permissions
+      actions: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Download artifact'
+        # this is the artifact created by
+        # "Upload diagrams for manual inspection"
+        uses: actions/github-script@v6.1.1
+        with:
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "output"
+            })[0];
+            const download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            const fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/mmdc-output.zip', Buffer.from(download.data));
+      - run: unzip mmdc-output.zip
+      - name: 'Upload to Percy'
+        # copied from https://docs.percy.io/docs/github-actions
+        # should automatically upload `.png`
+        run: npx @percy/cli upload ./
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          # Because we are not running on pull_request, but from a workflow_run,
+          # we need to manually set the percy env vars,
+          # se https://docs.percy.io/docs/environment-variables
+          #
+          # Is it possible for there to be multiple PRs in the workflow_run event??
+          PERCY_PULL_REQUEST: ${{ github.event.workflow_run.pull_requests[0].number }}
+          PERCY_COMMIT: ${{ github.event.workflow_run.head_sha }}
+          PERCY_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          # this env should not be needed, since Percy will automatically use
+          # GitHub's API to figure it out from the PULL_REQUEST number
+          # PERCY_TARGET_BRANCH: ${{ github.event.workflow_run.pull_requests[0].base.ref }}
+          # PERCY_TARGET_COMMIT: ${{ github.event.workflow_run.pull_requests[0].base.sha }}


### PR DESCRIPTION
## :bookmark_tabs: Summary

Uploading to Percy from a `pull_request` GitHub Action fails from forks, since they do not have access to our private `${{ secrets.PERCY_TOKEN }}` variable.

However, according to GitHub's official docs, (https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) we can have a `workflow_run` action that automatically runs after the `pull_request` action, and that can have access to the `secrets.PERCY_TOKEN`
folder.

I think this resolves #364, but to test this, we'll have to make another PR after this PR is merged (I have https://github.com/aloisklink/mermaid-cli/pull/2 ready to go)

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
