### PR TITLE
Close `parseMMD` puppeteer page memory leak

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,6 @@ const convertToValidXML = html => {
 }
 
 async function cli () {
-// TODO: This is currently unindented to make `git diff` easier for PR reviewers.
   const commander = new Command()
   commander
     .version(pkg.version)
@@ -268,7 +267,6 @@ async function run (input, output, { puppeteerConfig = {}, quiet = false, parseM
   const mermaidChartsInMarkdownRegex = new RegExp(mermaidChartsInMarkdown)
   const browser = await puppeteer.launch(puppeteerConfig)
   try {
-  // TODO: indent this (currently unindented to make `git diff` smaller)
     const definition = await getInputData(input)
     if (/\.md$/.test(input)) {
       const diagrams = []


### PR DESCRIPTION
## :bookmark_tabs: Summary

Wraps the `parseMMD` function in a `try ... finally ...` block to automatically run puppeteer's `page.close()` function when `parseMDD` exits.

It's very minor, since normally mermaid-cli exits very quickly, but on the off chance somebody is using `mermaid-cli` on a giant markdown file with 100s of diagrams (e.g. a book using Pandoc), then this will improve their memory usage.

## :straight_ruler: Design Decisions

Because the entire `parseMDD` function has been indented, the `git diff` is a bit complicated. Let me know if you want me to split it up into two commits to make reviewing easier:
  - `fix: close parseMMD page memory leak`
  - `style: fix parseMMD indentation`

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
  - Not added, since the bugfix is pretty straightforward (and unit tests for memory leaks will be very hard in JavaScript)
- [x] :bookmark: targeted `master` branch
