### PR TITLE
test: make animated SVG static for first 3seconds

### DIFF
--- a/docs/animated-flowchart.svg
+++ b/docs/animated-flowchart.svg
@@ -17,7 +17,10 @@
   0% {
     stroke-dashoffset: 1000;
   }
-
+  10% {
+    /* No animation for the first 10% for consistent visual testing screenshots */
+    stroke-dashoffset: 1000;
+  }
   100% {
   }
 }

--- a/test-positive/flowchart1.css
+++ b/test-positive/flowchart1.css
@@ -17,7 +17,10 @@
   0% {
     stroke-dashoffset: 1000;
   }
-
+  10% {
+    /* No animation for the first 10% for consistent visual testing screenshots */
+    stroke-dashoffset: 1000;
+  }
   100% {
   }
 }


### PR DESCRIPTION
## :bookmark_tabs: Summary

Currently, the `flowchart1-with-css-{svg,png}.png` file is constantly animated. Since there is a slight bit of random delay when converting this animated SVG to a static picture, each PNG file is slightly different, causing Percy to throw an error, showing that the files have changed slightly.

Example Percy errors:
  - https://percy.io/Mermaid/mermaid-cli/builds/21195151/changed/1182895944?browser=chrome&browser_ids=22%2C23&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=313&widths=313

This commit makes the animated SVG static for the first 3 seconds, allowing for `mermaid-cli` and `convert-svg-to-png` to always take the same snapshot.

## :straight_ruler: Design Decisions

The animation is only paused for the first 3 seconds, but from my basic testing, this seems to be fine and the output looks constant.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
