### PR TITLE
fix: Error when mermaid diagram contains images 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,8 +61,11 @@ const getInputData = async inputFile => new Promise((resolve, reject) => {
 })
 
 const convertToValidXML = html => {
+  // Add trailing slash inside img tags
+  const formattedHtml = html.replace(/<img(.*?)>/gi, '<img$1 />')
+
   // <br> tags in valid HTML (from innerHTML) look like <br>, but they must look like <br/> to be valid XML (such as SVG)
-  return html.replace(/<br>/gi, '<br/>')
+  return formattedHtml.replace(/<br>/gi, '<br/>')
 }
 
 async function cli () {


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fix error inside **img tags** when mmd contains images as anchor points

Issue (https://github.com/mermaid-js/mermaid-cli/issues/376)

## :straight_ruler: Design Decisions

Following the previous implementation with which the br tags were formatted, a regular expression was used with which it searches for all the **img tags** that do not end with a slash and replaces a new img tag that does close with the slash, saving in the contents.

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [ ] :bookmark: targeted `master` branch
