### PR TITLE
fix: detect spaced codeblocks (#317 #342)

### DIFF
--- a/src-test/test.js
+++ b/src-test/test.js
@@ -165,7 +165,7 @@ describe('mermaid-cli', () => {
   }, timeout)
 
   test('should write multiple SVGs for default .md input by default', async () => {
-    const expectedOutputFiles = [1, 2, 3].map((i) => join('test-positive', `mermaid.md-${i}.svg`))
+    const expectedOutputFiles = [1, 2, 3, 10, 11].map((i) => join('test-positive', `mermaid.md-${i}.svg`))
     // delete any files from previous test (fs.rm added in Node v14.14.0)
     await Promise.all(expectedOutputFiles.map((file) => fs.rm(file, { force: true })))
 

--- a/src-test/test.js
+++ b/src-test/test.js
@@ -164,8 +164,17 @@ describe('mermaid-cli', () => {
     ).rejects.toThrow('Parse error on line 2')
   }, timeout)
 
+  test('should have 3 trailing spaces after ``` in test-positive/mermaid.md for case 9.', async () => {
+    // test if test case 9. for the next test is in required state
+    const data = await fs.readFile('test-positive/mermaid.md', { encoding: 'utf8' })
+    const regex = /9\.\s+space-appended\.mmd(.+)%%\s↑↑↑↑↑↑↑↑↑ should still find mermaid code even with trailing spaces after the/sg
+    const matches = data.match(regex)
+    await expect(matches.length).toBeGreaterThan(0)
+    await expect(matches[0].includes('```   ')).toBeTruthy()
+  }, timeout)
+
   test('should write multiple SVGs for default .md input by default', async () => {
-    const expectedOutputFiles = [1, 2, 3, 10, 11].map((i) => join('test-positive', `mermaid.md-${i}.svg`))
+    const expectedOutputFiles = [1, 2, 3, 8, 9].map((i) => join('test-positive', `mermaid.md-${i}.svg`))
     // delete any files from previous test (fs.rm added in Node v14.14.0)
     await Promise.all(expectedOutputFiles.map((file) => fs.rm(file, { force: true })))
 

--- a/src/index.js
+++ b/src/index.js
@@ -269,7 +269,7 @@ async function run (input, output, { puppeteerConfig = {}, quiet = false, output
     }
   }
 
-  const mermaidChartsInMarkdown = /^```(?:mermaid)(\r?\n([\s\S]*?))```$/
+  const mermaidChartsInMarkdown = /^\s*```(?:mermaid)(\r?\n([\s\S]*?))```\s*$/
   const mermaidChartsInMarkdownRegexGlobal = new RegExp(mermaidChartsInMarkdown, 'gm')
   const mermaidChartsInMarkdownRegex = new RegExp(mermaidChartsInMarkdown)
   const browser = await puppeteer.launch(puppeteerConfig)

--- a/test-positive/mermaid.md
+++ b/test-positive/mermaid.md
@@ -113,33 +113,7 @@ loop D-1 before deadline at 7:45
     Note over HII,FGG: D-1 before deadline
 end
 ```
-8. state1.mmd
-```mermaid
-stateDiagram
-    state Choose <<fork>>
-    [*] --> Still
-    Still --> [*]
-
-    Still --> Moving
-    Moving --> Choose
-    Choose --> Still
-    Choose --> Crash
-    Crash --> [*]
-```
-9. state2.mmd
-```mermaid
-stateDiagram
-    state Choose <<fork>>
-    [*] --> Still
-    Still --> [*]
-
-    Still --> Moving
-    Moving --> Choose
-    Choose --> Still
-    Choose --> Crash
-    Crash --> [*]
-```
-10. indented.mmd
+8. indented.mmd
     ```mermaid
     stateDiagram
         state Choose <<fork>>
@@ -152,7 +126,9 @@ stateDiagram
         Choose --> Crash
         Crash --> [*]
     ```
-11. space-appended.mmd
+9. space-appended.mmd
+%% ↑↑↑↑↑↑↑↑↑ used as regex-entry point in test.js
+%% ↓↓↓↓↓↓↓↓↓ should still find mermaid code even with trailing spaces after the ```
 ```mermaid
 stateDiagram
     state Choose <<fork>>
@@ -165,3 +141,4 @@ stateDiagram
     Choose --> Crash
     Crash --> [*]
 ```   
+%% ↑↑↑↑↑↑↑↑↑ should still find mermaid code even with trailing spaces after the ```

--- a/test-positive/mermaid.md
+++ b/test-positive/mermaid.md
@@ -139,3 +139,29 @@ stateDiagram
     Choose --> Crash
     Crash --> [*]
 ```
+10. indented.mmd
+    ```mermaid
+    stateDiagram
+        state Choose <<fork>>
+        [*] --> Still
+        Still --> [*]
+
+        Still --> Moving
+        Moving --> Choose
+        Choose --> Still
+        Choose --> Crash
+        Crash --> [*]
+    ```
+11. space-appended.mmd
+```mermaid
+stateDiagram
+    state Choose <<fork>>
+    [*] --> Still
+    Still --> [*]
+
+    Still --> Moving
+    Moving --> Choose
+    Choose --> Still
+    Choose --> Crash
+    Crash --> [*]
+```   


### PR DESCRIPTION
Signed-off-by: Andreas Ulm <andreas.ulm@skaylink.com>

## :bookmark_tabs: Summary

* detect indented mermaid codeblocks in MD (#317)
* detect space suffixed mermaid codeblocks in MD (#342)

Resolves #317 
Resolves #342 

## :straight_ruler: Design Decisions

Extended regular expression `mermaidChartsInMarkdown` with optional any number of spaces before and after codeblock fences.

Extended test case `should write multiple SVGs for default .md input by default` to include markdown code that has spaces. (10. = indented, 11. = spaces appended)

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
