### PR TITLE
feat: load title/desc text from Mermaid SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ graph
 sequenceDiagram
    [....]
 ```
+
+### Mermaid with custom title/desc
+```mermaid
+graph
+   accTitle: My title here
+   accDescr: My description here
+   A-->B
+```
 ~~~
 
 Becomes:
@@ -73,6 +81,9 @@ Becomes:
 
 ### Some more markdown
 ![diagram](./readme-2.svg)
+
+### Mermaid with custom title/desc
+![My description here](./readme-3.svg "My title here")
 ```
 
 ### Piping from stdin

--- a/test-positive/mermaid.md
+++ b/test-positive/mermaid.md
@@ -116,6 +116,9 @@ end
 8. indented.mmd
     ```mermaid
     stateDiagram
+        accTitle: State diagram example with \"double-quotes"
+        accDescr: State diagram describing movement states and containing [] square brackets and \[]
+
         state Choose <<fork>>
         [*] --> Still
         Still --> [*]


### PR DESCRIPTION
## :bookmark_tabs: Summary

Loads the title and/or description text from the Mermaid SVG for accessibility purposes.

In come countries, it is illegal to use images on a website without the appropriate alt text. Additionally, some markdown renderers use the alt text as a caption (e.g. Pandoc).

### Example

#### Input

The following mermaid code:

````markdown
```mermaid
stateDiagram
  accTitle: State diagram title here
  accDescr: State diagram description here

  state Choose <<fork>>
  Choose --> Still
```
````

aka (has `<title />` and `<desc/>` for people on screen readers)

```mermaid
stateDiagram
  accTitle: State diagram title here
  accDescr: State diagram description here

  state Choose <<fork>>
  Choose --> Still
```

#### Output

Will get converted to the following markdown image:

```markdown
![State diagram description here](./link-to-image.png "State diagram title here")
```

`[]` in the alt text and `"` in the title text are automatically escaped. _Edit_: `\` are also escaped to `\\`.

Resolves #316

## :straight_ruler: Design Decisions

~I've also changed the default alt text to `![Mermaid diagram](./image-1.png)` when it used to be `![diagram](./image-1.png)`.~

~It's a pretty small change, and I think it makes it slightly clearer for visually impaired users. But it might not be worth it, since it's technically a breaking change (e.g. @craigmac might need to modify their sed script in https://github.com/mermaid-js/mermaid-cli/issues/316#issue-1273682304)~

_Edit_: I decided to undo this in https://github.com/mermaid-js/mermaid-cli/commit/4671bf4e242919fd89bb046d774516ebbfb66b15 and just leave the default as `![diagram](./image-1.png)`, since it probably doesn't help too much for a visually impaired to know that a diagram is rendered by mermaid if they can't see the diagram.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
