### PR TITLE
test(mermaid.md): cleanup mermaid.md test case

### DIFF
--- a/src-test/test.js
+++ b/src-test/test.js
@@ -167,7 +167,7 @@ describe('mermaid-cli', () => {
   test('should have 3 trailing spaces after ``` in test-positive/mermaid.md for case 9.', async () => {
     // test if test case 9. for the next test is in required state
     const data = await fs.readFile('test-positive/mermaid.md', { encoding: 'utf8' })
-    const regex = /9\.\s+space-appended\.mmd(.+)%%\s↑↑↑↑↑↑↑↑↑ should still find mermaid code even with trailing spaces after the/sg
+    const regex = /9\.\s+Should still find mermaid code even with trailing spaces after the(.+)do not delete the trailing spaces after the/sg
     const matches = data.match(regex)
     await expect(matches.length).toBeGreaterThan(0)
     await expect(matches[0].includes('```   ')).toBeTruthy()

--- a/test-positive/mermaid.md
+++ b/test-positive/mermaid.md
@@ -113,7 +113,8 @@ loop D-1 before deadline at 7:45
     Note over HII,FGG: D-1 before deadline
 end
 ```
-8. indented.mmd
+8. Should still find mermaid code even when code-block is indented.
+
     ```mermaid
     stateDiagram
         state Choose <<fork>>
@@ -126,9 +127,9 @@ end
         Choose --> Crash
         Crash --> [*]
     ```
-9. space-appended.mmd
-%% ↑↑↑↑↑↑↑↑↑ used as regex-entry point in test.js
-%% ↓↓↓↓↓↓↓↓↓ should still find mermaid code even with trailing spaces after the ```
+
+9. Should still find mermaid code even with trailing spaces after the \`\`\`
+
 ```mermaid
 stateDiagram
     state Choose <<fork>>
@@ -140,5 +141,7 @@ stateDiagram
     Choose --> Still
     Choose --> Crash
     Crash --> [*]
+%% ↓↓↓ should still find mermaid code even with trailing spaces after the ```
 ```   
-%% ↑↑↑↑↑↑↑↑↑ should still find mermaid code even with trailing spaces after the ```
+
+**Warning**: do not delete the trailing spaces after the \`\`\`


### PR DESCRIPTION
## :bookmark_tabs: Summary

Cleans up the `test-positive/mermaid.md` file

The mermaid syntax in the file was technically incorrect, and some mermaid parsers (VS Code) were throwing an error due to the \`\`\` characters.

## :straight_ruler: Design Decisions

I delete the `indented.mmd` and `space-appended.mmd` lines, since there are no `indented.mmd` and/or `space-appended.mmd` files (these tests are just to check markdown rendering rules).

I've also moved the comment into the ```` ```mermaid ``` ```` code-block, since Mermaid supports comments, but Markdown doesn't.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
