### PR TITLE
ci(test): fix convert-svg-to-png in mermaid 9.1.7

### DIFF
--- a/test-positive/config-noUseMaxWidth.json
+++ b/test-positive/config-noUseMaxWidth.json
@@ -1,0 +1,34 @@
+{
+    "//comment": "Our CI/Percy tests use convert-svg-to-png, which needs explicit width, not useMaxWidth",
+    "//comment2": "Not recommended normally, since browsers may render SVGs slightly differently",
+    "flowchart": {
+        "useMaxWidth": false
+    },
+    "sequence": {
+        "useMaxWidth": false
+    },
+    "gantt": {
+        "useMaxWidth": false
+    },
+    "journey": {
+        "useMaxWidth": false
+    },
+    "class": {
+        "useMaxWidth": false
+    },
+    "state": {
+        "useMaxWidth": false
+    },
+    "er": {
+        "useMaxWidth": false
+    },
+    "pie": {
+        "useMaxWidth": false
+    },
+    "requirement": {
+        "useMaxWidth": false
+    },
+    "c4": {
+        "useMaxWidth": false
+    }
+}


### PR DESCRIPTION
## :bookmark_tabs: Summary

Mermaid v9.1.7 implemented commit https://github.com/mermaid-js/mermaid/commit/2968b400c49f66983e6d206959504e72aa6ae0ef that removes the `width` attr from SVGs by default, using the CSS `max-width` style instead.

Percy CI (used for visual regression tests) does not yet support SVGs, so we use convert-svg-to-png@v0.5.0, but that requires either the width or the height to calculate the size of the PNG to convert to SVG to.

To fix this, the Mermaid `useMaxWidth` option can be set to `false`. Annoyingly, we need to do this for every single graph type, see https://mermaid-js.github.io/mermaid/#/Setup?id=usemaxwidth

Should fix the failing CI in PR #383.

## :straight_ruler: Design Decisions

N/A

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
