### PR TITLE
Fixed -e flag option to place output format for files

### DIFF
--- a/src-test/test.js
+++ b/src-test/test.js
@@ -186,6 +186,36 @@ describe('mermaid-cli', () => {
     }))
   }, timeout)
 
+  test('should use png output', async () => {
+    const expectedOutputFiles = [1, 2, 3, 4, 5, 6, 7, 8, 9].map((i) => join('test-positive', `mermaid.md-${i}.png`))
+    await Promise.all(expectedOutputFiles.map((file) => fs.rm(file, { force: true })))
+    await promisify(execFile)('node', ['src/cli.js', '-e', 'png', '-i', 'test-positive/mermaid.md'])
+
+    await Promise.all(expectedOutputFiles.map(async (file) => {
+      expectBytesAreFormat(await fs.readFile(file), 'png')
+    }))
+  }, timeout)
+
+  test('should use svg output', async () => {
+    const expectedOutputFiles = [1, 2, 3, 4, 5, 6, 7, 8, 9].map((i) => join('test-positive', `mermaid.md-${i}.svg`))
+    await Promise.all(expectedOutputFiles.map((file) => fs.rm(file, { force: true })))
+    await promisify(execFile)('node', ['src/cli.js', '-e', 'svg', '-i', 'test-positive/mermaid.md'])
+
+    await Promise.all(expectedOutputFiles.map(async (file) => {
+      expectBytesAreFormat(await fs.readFile(file), 'svg')
+    }))
+  }, timeout)
+
+  test('should use pdf output', async () => {
+    const expectedOutputFiles = [1, 2, 3, 4, 5, 6, 7, 8, 9].map((i) => join('test-positive', `mermaid.md-${i}.pdf`))
+    await Promise.all(expectedOutputFiles.map((file) => fs.rm(file, { force: true })))
+    await promisify(execFile)('node', ['src/cli.js', '-e', 'pdf', '-i', 'test-positive/mermaid.md'])
+
+    await Promise.all(expectedOutputFiles.map(async (file) => {
+      expectBytesAreFormat(await fs.readFile(file), 'pdf')
+    }))
+  }, timeout)
+
   test.concurrent.each(['svg', 'png', 'pdf'])('should set red background to %s', async (format) => {
     await promisify(execFile)('node', [
       'src/cli.js', '-i', 'test-positive/flowchart1.mmd', '-o', `test-output/flowchart1-red-background.${format}`,
@@ -209,6 +239,10 @@ describe('mermaid-cli', () => {
 })
 
 describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {
+  describe('cli()', () => {
+    test('If no output specified, and no outputFormat')
+  })
+
   describe('run()', () => {
     test('should write markdown output with svg images', async () => {
       const expectedOutputMd = 'test-output/mermaid-run-output-test-svg.md'

--- a/src-test/test.js
+++ b/src-test/test.js
@@ -186,7 +186,7 @@ describe('mermaid-cli', () => {
     }))
   }, timeout)
 
-  test('should write png extension in output', async () => {
+  test('the .png extension should be added to .md files', async () => {
     const expectedOutputFiles = [1, 2, 3, 4, 5, 6, 7, 8, 9].map((i) => join('test-positive', `mermaid.md-${i}.png`))
     await Promise.all(expectedOutputFiles.map((file) => fs.rm(file, { force: true })))
     await promisify(execFile)('node', ['src/cli.js', '-e', 'png', '-i', 'test-positive/mermaid.md'])
@@ -196,7 +196,7 @@ describe('mermaid-cli', () => {
     }))
   }, timeout)
 
-  test('should write svg extension in output', async () => {
+  test('the .svg extension should be added to .md files', async () => {
     const expectedOutputFiles = [1, 2, 3, 4, 5, 6, 7, 8, 9].map((i) => join('test-positive', `mermaid.md-${i}.svg`))
     await Promise.all(expectedOutputFiles.map((file) => fs.rm(file, { force: true })))
     await promisify(execFile)('node', ['src/cli.js', '-e', 'svg', '-i', 'test-positive/mermaid.md'])
@@ -206,7 +206,7 @@ describe('mermaid-cli', () => {
     }))
   }, timeout)
 
-  test('should write pdf extension in output', async () => {
+  test('the .pdf extension should be added to .md files', async () => {
     const expectedOutputFiles = [1, 2, 3, 4, 5, 6, 7, 8, 9].map((i) => join('test-positive', `mermaid.md-${i}.pdf`))
     await Promise.all(expectedOutputFiles.map((file) => fs.rm(file, { force: true })))
     await promisify(execFile)('node', ['src/cli.js', '-e', 'pdf', '-i', 'test-positive/mermaid.md'])
@@ -214,6 +214,30 @@ describe('mermaid-cli', () => {
     await Promise.all(expectedOutputFiles.map(async (file) => {
       expectBytesAreFormat(await fs.readFile(file), 'pdf')
     }))
+  }, timeout)
+
+  test('the extension .pdf should be added for .mmd file', async () => {
+    const expectedOutputFile = 'test-positive/flowchart1.mmd.pdf'
+    await fs.rm(expectedOutputFile, { force: true })
+    await promisify(execFile)('node', ['src/cli.js', '-e', 'pdf', '-i', 'test-positive/flowchart1.mmd'])
+
+    expectBytesAreFormat(await fs.readFile(expectedOutputFile), 'pdf')
+  }, timeout)
+
+  test('the extension .svg should be added for .mmd file', async () => {
+    const expectedOutputFile = 'test-positive/flowchart1.mmd.svg'
+    await fs.rm(expectedOutputFile, { force: true })
+    await promisify(execFile)('node', ['src/cli.js', '-e', 'svg', '-i', 'test-positive/flowchart1.mmd'])
+
+    expectBytesAreFormat(await fs.readFile(expectedOutputFile), 'svg')
+  }, timeout)
+
+  test('the extension .png should be added for .mmd file', async () => {
+    const expectedOutputFile = 'test-positive/flowchart1.mmd.png'
+    await fs.rm(expectedOutputFile, { force: true })
+    await promisify(execFile)('node', ['src/cli.js', '-e', 'png', '-i', 'test-positive/flowchart1.mmd'])
+
+    expectBytesAreFormat(await fs.readFile(expectedOutputFile), 'png')
   }, timeout)
 
   test.concurrent.each(['svg', 'png', 'pdf'])('should set red background to %s', async (format) => {

--- a/src-test/test.js
+++ b/src-test/test.js
@@ -186,7 +186,7 @@ describe('mermaid-cli', () => {
     }))
   }, timeout)
 
-  test('should use png output', async () => {
+  test('should write png extension in output', async () => {
     const expectedOutputFiles = [1, 2, 3, 4, 5, 6, 7, 8, 9].map((i) => join('test-positive', `mermaid.md-${i}.png`))
     await Promise.all(expectedOutputFiles.map((file) => fs.rm(file, { force: true })))
     await promisify(execFile)('node', ['src/cli.js', '-e', 'png', '-i', 'test-positive/mermaid.md'])
@@ -196,7 +196,7 @@ describe('mermaid-cli', () => {
     }))
   }, timeout)
 
-  test('should use svg output', async () => {
+  test('should write svg extension in output', async () => {
     const expectedOutputFiles = [1, 2, 3, 4, 5, 6, 7, 8, 9].map((i) => join('test-positive', `mermaid.md-${i}.svg`))
     await Promise.all(expectedOutputFiles.map((file) => fs.rm(file, { force: true })))
     await promisify(execFile)('node', ['src/cli.js', '-e', 'svg', '-i', 'test-positive/mermaid.md'])
@@ -206,7 +206,7 @@ describe('mermaid-cli', () => {
     }))
   }, timeout)
 
-  test('should use pdf output', async () => {
+  test('should write pdf extension in output', async () => {
     const expectedOutputFiles = [1, 2, 3, 4, 5, 6, 7, 8, 9].map((i) => join('test-positive', `mermaid.md-${i}.pdf`))
     await Promise.all(expectedOutputFiles.map((file) => fs.rm(file, { force: true })))
     await promisify(execFile)('node', ['src/cli.js', '-e', 'pdf', '-i', 'test-positive/mermaid.md'])
@@ -239,10 +239,6 @@ describe('mermaid-cli', () => {
 })
 
 describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {
-  describe('cli()', () => {
-    test('If no output specified, and no outputFormat')
-  })
-
   describe('run()', () => {
     test('should write markdown output with svg images', async () => {
       const expectedOutputMd = 'test-output/mermaid-run-output-test-svg.md'

--- a/src/index.js
+++ b/src/index.js
@@ -98,7 +98,11 @@ async function cli () {
   // if an input file is defined, it should take precedence, otherwise, input is
   // coming from stdin and just name the file out.svg, if it hasn't been
   // specified with the '-o' option
-    output = input ? (input + '.svg') : 'out.svg'
+    if(outputFormat) {
+      output = input ? (input + '.' + outputFormat) : 'out' + '.' + outputFormat
+    } else {
+      output = input ? (input + '.svg') : 'out.svg'
+    }
   }
   if (!/\.(?:svg|png|pdf|md)$/.test(output)) {
     error('Output file must end with ".md", ".svg", ".png" or ".pdf"')

--- a/src/index.js
+++ b/src/index.js
@@ -98,7 +98,7 @@ async function cli () {
   // if an input file is defined, it should take precedence, otherwise, input is
   // coming from stdin and just name the file out.svg, if it hasn't been
   // specified with the '-o' option
-    if(outputFormat) {
+    if (outputFormat) {
       output = input ? (`${input}.${outputFormat}`) : `out.${outputFormat}`
     } else {
       output = input ? (`${input}.svg`) : 'out.svg'

--- a/src/index.js
+++ b/src/index.js
@@ -99,9 +99,9 @@ async function cli () {
   // coming from stdin and just name the file out.svg, if it hasn't been
   // specified with the '-o' option
     if(outputFormat) {
-      output = input ? (input + '.' + outputFormat) : 'out' + '.' + outputFormat
+      output = input ? (`${input}.${outputFormat}`) : `out.${outputFormat}`
     } else {
-      output = input ? (input + '.svg') : 'out.svg'
+      output = input ? (`${input}.svg`) : 'out.svg'
     }
   }
   if (!/\.(?:svg|png|pdf|md)$/.test(output)) {


### PR DESCRIPTION
## :bookmark_tabs: Summary

Brief description about the content of your PR.

Fixing  `-e` flag option to place output format to the file.

Resolves #394 

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

Added an `if` statement to check if `-e` flag is given. If so then the extension is added to the output file by assigning the `output` variable with the extension specified. Also added additional tests to see if the logic is working. 

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
