### PR TITLE
Correct compatible Node.JS version in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "mmdc": "./src/cli.js"
   },
   "engines": {
-    "node": ">=14.1.0"
+    "node": "^14.13 || >=16.0"
   },
   "exports": "./src/index.js",
   "scripts": {


### PR DESCRIPTION
Update compatible version of node-js as required by chalk and puppeteer

I had found that node-js 14.1 does not work. As per discussion on mermaid slack, `puppeteer` requires >= 14.1.0 but this is superseded by `chalk` which only allows 14.13, or >=16.0.0.

## :bookmark_tabs: Summary

A brief change to `package.json` for which version of node-js are allowed.

## :straight_ruler: Design Decisions

N/A

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
