### PR TITLE
fix: handle empty newlines before diagrams in md

### DIFF
--- a/src-test/test.js
+++ b/src-test/test.js
@@ -316,6 +316,9 @@ describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {
         '(./mermaid-run-output-test-png-8.png "State diagram example with \\\\\\"double-quotes\\"")')
       expect(markdownFile).toContain(markdownImageWithCustomTitle)
 
+      // check whether newlines before/after mermaid diagram are kept
+      expect(markdownFile).toContain('There should be an empty newline after this line, but before the Mermaid diagram:\n\n')
+
       // files should exist, and they should be PNGs
       await Promise.all(expectedOutputPngs.map(async (expectedOutputPng) => {
         // markdown file should point to png relative to md file

--- a/src/index.js
+++ b/src/index.js
@@ -364,7 +364,8 @@ async function run (input, output, { puppeteerConfig = {}, quiet = false, output
     }
   }
 
-  const mermaidChartsInMarkdown = /^\s*```(?:mermaid)(\r?\n([\s\S]*?))```\s*$/
+  // TODO: should we use a Markdown parser like remark instead of rolling our own parser?
+  const mermaidChartsInMarkdown = /^[^\S\n]*```(?:mermaid)(\r?\n([\s\S]*?))```[^\S\n]*$/
   const mermaidChartsInMarkdownRegexGlobal = new RegExp(mermaidChartsInMarkdown, 'gm')
   const browser = await puppeteer.launch(puppeteerConfig)
   try {

--- a/test-positive/mermaid.md
+++ b/test-positive/mermaid.md
@@ -83,6 +83,9 @@ graph LR
     A -->|こんにちは| B
 ```
 7. sequence.mmd
+
+There should be an empty newline after this line, but before the Mermaid diagram:
+
 ```mermaid
 sequenceDiagram
 %% See https://mermaidjs.github.io/sequenceDiagram.html
@@ -103,6 +106,7 @@ loop D-1 before deadline at 7:45
     Note over HII,FGG: D-1 before deadline
 end
 ```
+
 8. Should still find mermaid code even when code-block is indented.
 
     ```mermaid


### PR DESCRIPTION
## :bookmark_tabs: Summary

Handles empty newlines before and after diagrams in Markdown.

For example, the following Markdown:

````markdown
My text.

```mermaid
  my diagram
```
````

Should get converted to:

```markdown
My text.

![diagram](./my-diagram)
```

However, currently, the empty newline is removed.
We can fix this by making sure that our Regex ignores newlines outside of the Mermaid diagram code.

Fixes: 9d7b4b29d3dfcaa21f4639314aadf09fe4ccbe19 (where bug was introduced)
Fixes: https://github.com/mermaid-js/mermaid-cli/issues/413

## :straight_ruler: Design Decisions

Instead of using `\s` to find all whitespace, I'm instead using `[^\S\n]` to find anything that is not a non-whitespace character nor `\n` (basically any `\s` that is not `\n`).

In the future, it might be worth instead using https://github.com/remarkjs/remark to handle Markdown parsing, since there are probably a bunch of edge-cases that we can't handle using simplistic regex. 

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
