### PR TITLE
FIX #435: Use absolute path for the entrypoint

### DIFF
--- a/DockerfileBuild
+++ b/DockerfileBuild
@@ -28,5 +28,5 @@ WORKDIR /home/mermaidcli
 RUN yarn add $(ls -d /install/*.tgz)
 
 ADD puppeteer-config.json  /puppeteer-config.json
-ENTRYPOINT ["./node_modules/.bin/mmdc", "-p", "/puppeteer-config.json"]
+ENTRYPOINT ["/home/mermaidcli/node_modules/.bin/mmdc", "-p", "/puppeteer-config.json"]
 CMD [ "--help" ]


### PR DESCRIPTION

Following our discussion on issue #435 