### PR TITLE
Improve `stdin` input handling on (fixes Windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ You can easily pipe input from stdin. This example shows how to use a heredoc to
 send a diagram as stdin to mermaid-cli (mmdc).
 
 ```sh
-cat << EOF  | mmdc
+cat << EOF  | mmdc --input -
     graph TD
     A[Client] --> B[Load Balancer]
 EOF

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ const error = message => {
 }
 
 const warn = message => {
-  console.log(chalk.yellow(`\n${message}\n`))
+  console.warn(chalk.yellow(`\n${message}\n`))
 }
 
 const checkConfigFile = file => {


### PR DESCRIPTION
## :bookmark_tabs: Summary

Improves how `mmdc` handles `stdin` inputs.

Currently, running `mmdc` exits with an error if it cannot find an stdin. However, it does this by checking if the stdin is a FIFO, which is only true in some cases.
(it seems to fail on Windows and other non-bash shells).

I've changed `mmdc` to always read from stdin if there is no `--input`. However, it prints a warning:

```console
user@pc:~/mermaid-cli $ node src/cli.js

No input file specfied, reading from stdin. If you want to specify an input file, please use `-i <input>.` You can use `-i -` to read from stdin and to suppress this warning.
```

To suppress this warning, you can run mmdc with `--input -` (this is what many CLI tools, like `cat` does).

Resolves https://github.com/mermaid-js/mermaid-cli/issues/468 (although I haven't tested it, since I don't a Windows machine).

## :straight_ruler: Design Decisions

In the future, we can also simplify https://github.com/mermaid-js/mermaid-cli/blob/240921a7d3698406cf044c62ae657852dddcd359/src-test/test.js#L30-L32 to avoid shell injection warnings (like the one in https://github.com/mermaid-js/mermaid-cli/security/code-scanning/7).

I hadn't done it previously, because Node.JS doesn't use a FIFO for stdin.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
