### PR TITLE
Support the `.markdown` file extension for markdown files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -121,8 +121,8 @@ async function cli () {
       output = input ? (`${input}.svg`) : 'out.svg'
     }
   }
-  if (!/\.(?:svg|png|pdf|md)$/.test(output)) {
-    error('Output file must end with ".md", ".svg", ".png" or ".pdf"')
+  if (!/\.(?:svg|png|pdf|md|markdown)$/.test(output)) {
+    error('Output file must end with ".md"/".markdown", ".svg", ".png" or ".pdf"')
   }
   const outputDir = path.dirname(output)
   if (!fs.existsSync(outputDir)) {
@@ -346,10 +346,11 @@ function markdownImage ({ url, title, alt }) {
 /**
  * Renders a mermaid diagram or mermaid markdown file.
  *
- * @param {`${string}.md` | string} [input] - If this ends with `.md`, path to a markdown file containing mermaid.
+ * @param {`${string}.${"md" | "markdown"}` | string} [input] - If this ends with `.md`/`.markdown`,
+ * path to a markdown file containing mermaid.
  * If this is a string, loads the mermaid definition from the given file.
  * If this is `undefined`, loads the mermaid definition from stdin.
- * @param {`${string}.${"md" | "svg" | "png" | "pdf"}`} output - Path to the output file.
+ * @param {`${string}.${"md" | "markdown" | "svg" | "png" | "pdf"}`} output - Path to the output file.
  * @param {Object} [opts] - Options
  * @param {puppeteer.LaunchOptions} [opts.puppeteerConfig] - Puppeteer launch options.
  * @param {boolean} [opts.quiet] - If set, suppress log output.
@@ -372,7 +373,7 @@ async function run (input, output, { puppeteerConfig = {}, quiet = false, output
     if (!outputFormat) {
       outputFormat = path.extname(output).replace('.', '')
     }
-    if (outputFormat === 'md') {
+    if (outputFormat === 'md' || outputFormat === 'markdown') {
       // fallback to svg in case no outputFormat is given and output file is MD
       outputFormat = 'svg'
     }
@@ -381,7 +382,7 @@ async function run (input, output, { puppeteerConfig = {}, quiet = false, output
     }
 
     const definition = await getInputData(input)
-    if (/\.md$/.test(input)) {
+    if (/\.(md|markdown)$/.test(input)) {
       const imagePromises = []
       for (const mermaidCodeblockMatch of definition.matchAll(mermaidChartsInMarkdownRegexGlobal)) {
         const mermaidDefinition = mermaidCodeblockMatch[1]
@@ -391,7 +392,10 @@ async function run (input, output, { puppeteerConfig = {}, quiet = false, output
         //     I.e. if "out.png", use "out-1.png", "out-2.png", etc
         //   If it is an output `.md` file, use that to base .svg numbered diagrams on
         //     I.e. if "out.md". use "out-1.svg", "out-2.svg", etc
-        const outputFile = output.replace(/(\.(md|png|svg|pdf))$/, `-${imagePromises.length + 1}$1`).replace(/(\.md)$/, `.${outputFormat}`)
+        const outputFile = output.replace(
+          /(\.(md|markdown|png|svg|pdf))$/,
+          `-${imagePromises.length + 1}$1`
+        ).replace(/\.(md|markdown)$/, `.${outputFormat}`)
         const outputFileRelative = `./${path.relative(path.dirname(path.resolve(output)), path.resolve(outputFile))}`
 
         const imagePromise = (async () => {
@@ -416,7 +420,7 @@ async function run (input, output, { puppeteerConfig = {}, quiet = false, output
 
       const images = await Promise.all(imagePromises)
 
-      if (/\.md$/.test(output)) {
+      if (/\.(md|markdown)$/.test(output)) {
         const outDefinition = definition.replace(mermaidChartsInMarkdownRegexGlobal, (_mermaidMd) => {
           // pop first image from front of array
           const { url, title, alt } = images.shift()

--- a/test-positive/erDiagram.markdown
+++ b/test-positive/erDiagram.markdown
@@ -1,0 +1,18 @@
+# Mermaid
+
+This file tests whether the `.mermaid` extension works.
+
+## ER Diagram
+
+The following diagram is an example
+[entity relationship diagram](https://mermaid.js.org/syntax/entityRelationshipDiagram.html)
+
+```mermaid
+---
+title: Order example
+---
+erDiagram
+    CUSTOMER ||--o{ ORDER : places
+    ORDER ||--|{ LINE-ITEM : contains
+    CUSTOMER }|..|{ DELIVERY-ADDRESS : uses
+```


### PR DESCRIPTION
## :bookmark_tabs: Summary

Support using markdown files as an input/output that have a `.markdown` file extension, instead of just `.md`.

Resolves #471

## :straight_ruler: Design Decisions

I've basically just added `.markdown` everywhere I could find `.md`.

I haven't bothered adding it to the `mmdc --help` text, since I feel like most people use `.md`, not `.markdown`, and I don't want to make the `--help` text more complicated.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
