### PR TITLE
Support trailing spaces after '```mermaid'

### DIFF
--- a/src-test/test.js
+++ b/src-test/test.js
@@ -173,6 +173,15 @@ describe('mermaid-cli', () => {
     await expect(matches[0].includes('```   ')).toBeTruthy()
   }, timeout)
 
+  test('should have 5 trailing spaces after ```mermaid in test-positive/mermaid.md for case 9.', async () => {
+    // make sure that we don't accidentally delete the trailing spaces in test 9
+    const data = await fs.readFile('test-positive/mermaid.md', { encoding: 'utf8' })
+    const regex = /9\.\s+Should still find mermaid code even with trailing spaces after the(.+)do not delete the trailing spaces after the/sg
+    const matches = data.match(regex)
+    await expect(matches.length).toBeGreaterThan(0)
+    await expect(matches[0].includes('```mermaid     ')).toBeTruthy()
+  }, timeout)
+
   test('should write multiple SVGs for default .md input by default', async () => {
     const expectedOutputFiles = [1, 2, 3, 8, 9].map((i) => join('test-positive', `mermaid.md-${i}.svg`))
     // delete any files from previous test (fs.rm added in Node v14.14.0)

--- a/src/index.js
+++ b/src/index.js
@@ -365,7 +365,7 @@ async function run (input, output, { puppeteerConfig = {}, quiet = false, output
   }
 
   // TODO: should we use a Markdown parser like remark instead of rolling our own parser?
-  const mermaidChartsInMarkdown = /^[^\S\n]*```(?:mermaid)(\r?\n([\s\S]*?))```[^\S\n]*$/
+  const mermaidChartsInMarkdown = /^[^\S\n]*```(?:mermaid)([^\S\n]*\r?\n([\s\S]*?))```[^\S\n]*$/
   const mermaidChartsInMarkdownRegexGlobal = new RegExp(mermaidChartsInMarkdown, 'gm')
   const browser = await puppeteer.launch(puppeteerConfig)
   try {

--- a/test-positive/mermaid.md
+++ b/test-positive/mermaid.md
@@ -125,9 +125,11 @@ end
         Crash --> [*]
     ```
 
-9. Should still find mermaid code even with trailing spaces after the \`\`\`
+9. Should still find mermaid code even with trailing spaces after the opening
+`` ```mermaid `` and closing `` ``` ``.
 
-```mermaid
+```mermaid     
+%%        ↑↑↑↑↑ spaces should be above here.
 stateDiagram
     state Choose <<fork>>
     [*] --> Still


### PR DESCRIPTION
## :bookmark_tabs: Summary

Support trailing whitespace on the same line and after the opening
`` ```mermaid block ``, by adding a `[^\S\n]*` to the regex.

`[^\S\n]` is anything that is `\s` (whitespace char), except `\n`.

Resolves #487

## :straight_ruler: Design Decisions

I wonder if we should just give up on trying to parse Markdown ourselves and switch to using something like [Remark](https://github.com/remarkjs/remark) to do it for us.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
- [ ] **Give @infchg a chance to respond, in case they want a `Co-authored-by` credit in the commit message**
