### PR TITLE
build(deps-dev): switch to fontawesome v5

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,12 @@
   <body>
     <div id="container"></div>
     <script type="module">
-      import faBrands from "@fortawesome/fontawesome-free-webfonts/css/fa-brands.css"
-      import faRegular from "@fortawesome/fontawesome-free-webfonts/css/fa-regular.css"
-      import faSolid from "@fortawesome/fontawesome-free-webfonts/css/fa-solid.css"
-      import fontawesome from "@fortawesome/fontawesome-free-webfonts/css/fontawesome.css"
+      // don't import minified CSS files (e.g. `*.min.css`), since that actually
+      // makes the dist/index.html slightly larger!
+      import faBrands from "@fortawesome/fontawesome-free/css/brands.css"
+      import faRegular from "@fortawesome/fontawesome-free/css/regular.css"
+      import faSolid from "@fortawesome/fontawesome-free/css/solid.css"
+      import fontawesome from "@fortawesome/fontawesome-free/css/fontawesome.css"
 
       import mermaid from "mermaid"
       import mermaidMindmap from "@mermaid-js/mermaid-mindmap"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "puppeteer": "^19.0.0"
   },
   "devDependencies": {
-    "@fortawesome/fontawesome-free-webfonts": "^1.0.9",
+    "@fortawesome/fontawesome-free": "^5.6.0",
     "@mermaid-js/mermaid-mindmap": "^9.2.2",
     "@tsconfig/node14": "^1.0.3",
     "jest": "^29.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -455,9 +455,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fortawesome/fontawesome-free-webfonts@^1.0.9":
-  version "1.0.9"
-  resolved "https://registry.npmjs.org/@fortawesome/fontawesome-free-webfonts/-/fontawesome-free-webfonts-1.0.9.tgz"
+"@fortawesome/fontawesome-free@^5.6.0":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.4.tgz#ecda5712b61ac852c760d8b3c79c96adca5554e5"
+  integrity sha512-eYm8vijH/hpzr/6/1CJ/V/Eb1xQFW2nnUKArb3z+yUWv7HTwj6M7SP957oMjfZjAHU6qpoNc2wQvIxBLWYa/Jg==
 
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"


### PR DESCRIPTION
## :bookmark_tabs: Summary

The mermaid-cli project is currently using the very old and very deprecated [@fontawesome/fontawesome-free-webfonts][1] package that hasn't been updated in 5 years (since 2018-05-10).

According to [fontawesome's `UPGRADING.md` guide][2], the new package we should switch to is [@fontawesome/fontawesome-free][3].

## :straight_ruler: Design Decisions

Although fontawesome v5 adds official JavaScript support, I've kept the same CSS imports we had previously, in order to avoid the risk of breaking anything.

The fontawesome license has slightly changed, but as long as we keep their licensing info in the files in `dist/` (which we do), then it's all fine, see [LICENSE.txt][4].

[1]: https://www.npmjs.com/package/@fortawesome/fontawesome-free-webfonts
[2]: https://github.com/FortAwesome/Font-Awesome/blob/5.x/UPGRADING.md#50x-to-510
[3]: https://www.npmjs.com/package/@fortawesome/fontawesome-free
[4]: https://github.com/FortAwesome/Font-Awesome/blob/afecf2af5d897b763e5e8e28d46aad2f710ccad6/LICENSE.txt

### Breaking changes

The only minor breaking change that I could find is that `fa-tripadvisor` no longer works, due a legal request from Tripadvisor, https://fontawesome.com/v4/icon/tripadvisor.

All of the other breaking changes listed in https://github.com/FortAwesome/Font-Awesome/blob/5.x/UPGRADING.md only seem to affect new icons.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
