### PR TITLE
Update documentation for `--pdfFit` to accurately reflect it as a boolean

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -114,7 +114,7 @@ async function cli () {
     .option('-c, --configFile [configFile]', 'JSON configuration file for mermaid.')
     .option('-C, --cssFile [cssFile]', 'CSS file for the page.')
     .addOption(new Option('-s, --scale [scale]', 'Puppeteer scale factor').argParser(parseCommanderInt).default(1))
-    .option('-f, --pdfFit [pdfFit]', 'Scale PDF to fit chart')
+    .option('-f, --pdfFit', 'Scale PDF to fit chart')
     .option('-q, --quiet', 'Suppress log output')
     .option('-p --puppeteerConfigFile [puppeteerConfigFile]', 'JSON configuration file for puppeteer.')
     .parse(process.argv)


### PR DESCRIPTION
## :bookmark_tabs: Summary

The documentation of the CLI indicates that pdfFit takes a parameter. This is confusing, because pdfFit is simply a boolean.

This PR updates the documentation to indicate that pdfFit is a boolean.

## :clipboard: Tasks

Make sure you

- [X] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [X] :computer: have added unit/e2e tests - not relevant for a documentation change
- [X] :bookmark: targeted `master` branch
