### PR TITLE
ci(compile-mermaid): bump timeout to 90 minutes

### DIFF
--- a/.github/workflows/compile-mermaid.yml
+++ b/.github/workflows/compile-mermaid.yml
@@ -4,7 +4,7 @@ concurrency: ci-${{ github.ref }}
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 90
 
     env:
       DOCKERFILE: DockerfileBuild


### PR DESCRIPTION
## :bookmark_tabs: Summary

It looks like the **Build and Push Image(s)** step is a bit slow. Sometimes, it times out, as it takes 25–30 minutes.

Bumping the timeout to 90 minutes means that hopefully the CI run will stop timing out.

## :straight_ruler: Design Decisions

I picked 90 minutes since I'm guessing a slow run will take 35 to 40 minutes, and I usually like to have a 2x headroom on timeouts, since you never know when DockerHub/GitHub/Alpine will have a slow day.

**Example failing CI runs due to timeout**:
- https://github.com/mermaid-js/mermaid-cli/actions/runs/4542097531/jobs/8005083565

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
