### PR TITLE
test: increase jest test timeout to 60s

### DIFF
--- a/src-test/test.js
+++ b/src-test/test.js
@@ -103,8 +103,8 @@ afterAll(async () => {
   }
 })
 
-// 30 second timeout, this needs to be set higher than normal since CI is slow
-const timeout = 30000
+// 60 second timeout, this needs to be set higher than normal since CI is slow
+const timeout = 60000
 
 describe('mermaid-cli', () => {
   beforeAll(async () => {


### PR DESCRIPTION
## :bookmark_tabs: Summary

It looks like some of the jest tests are very occasionally timing out in CI.

This might be because GitHub Actions is slower now, or that Mermaid is slower with the newer diagrams.

Doubling the current jest timeout from 30s to 60s should fix this.

Should fix the following error:

> ```
>   ● mermaid-cli › the .svg extension should be added to .md files
> 
>     thrown: "Exceeded timeout of 30000 ms for a test.
>     Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."
> 
>       225 |   }, timeout)
>       226 |
>     > 227 |   test('the .svg extension should be added to .md files', async () => {
>           |   ^
>       228 |     const expectedOutputFiles = [1, 2, 3, 4, 5, 6, 7, 8, 9].map((i) => join('test-positive', `mermaid.md-${i}.svg`))
>       229 |     await Promise.all(expectedOutputFiles.map((file) => fs.rm(file, { force: true })))
>       230 |     await promisify(execFile)('node', ['src/cli.js', '-e', 'svg', '-i', 'test-positive/mermaid.md'])
> 
>       at test (src-test/test.js:227:3)
>       at describe (src-test/test.js:109:1)
> ```
>
> Error logs taken from https://github.com/mermaid-js/mermaid-cli/actions/runs/4557566654/jobs/8039366805

## :straight_ruler: Design Decisions

I've picked 60s, since it's double 30s, which almost always works.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
