### PR TITLE
build: remove dependency on mermaid-mindmap pkg

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,9 @@
       import fontawesome from "@fortawesome/fontawesome-free/css/fontawesome.css"
 
       import mermaid from "mermaid"
-      import mermaidMindmap from "@mermaid-js/mermaid-mindmap"
 
       // expose mermaid to the global scope so that puppeteer can see it
       globalThis.mermaid = mermaid
-      globalThis.mermaidMindmap = mermaidMindmap
     </script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^5.6.0",
-    "@mermaid-js/mermaid-mindmap": "^9.2.2",
     "@tsconfig/node14": "^1.0.3",
     "jest": "^29.0.1",
     "mermaid": "^10.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -258,11 +258,8 @@ async function renderMermaid (browser, definition, outputFormat, { viewport, bac
        * We've already imported these modules in our `index.html` file, so that they
        * get correctly bundled.
        * @property {import("mermaid")["default"]} mermaid Already imported mermaid instance
-       * @property {import("@mermaid-js/mermaid-mindmap")} mermaidMindmap Already imported mermaid-mindmap plugin
        */
-      const { mermaid, mermaidMindmap } = /** @type {GlobalThisWithMermaid & typeof globalThis} */ (globalThis)
-
-      await mermaid.registerExternalDiagrams([mermaidMindmap])
+      const { mermaid } = /** @type {GlobalThisWithMermaid & typeof globalThis} */ (globalThis)
 
       mermaid.initialize(mermaidConfig)
       // should throw an error if mmd diagram is invalid

--- a/yarn.lock
+++ b/yarn.lock
@@ -729,19 +729,6 @@
   dependencies:
     "@types/react" ">=16.0.0"
 
-"@mermaid-js/mermaid-mindmap@^9.2.2":
-  version "9.3.0"
-  resolved "https://registry.yarnpkg.com/@mermaid-js/mermaid-mindmap/-/mermaid-mindmap-9.3.0.tgz#cfe10329198a0f37e27eef1dcc4a1cf21f187e2b"
-  integrity sha512-IhtYSVBBRYviH1Ehu8gk69pMDF8DSRqXBRDMWrEfHoaMruHeaP2DXA3PBnuwsMaCdPQhlUUcy/7DBLAEIXvCAw==
-  dependencies:
-    "@braintree/sanitize-url" "^6.0.0"
-    cytoscape "^3.23.0"
-    cytoscape-cose-bilkent "^4.1.0"
-    cytoscape-fcose "^2.1.0"
-    d3 "^7.0.0"
-    khroma "^2.0.0"
-    non-layered-tidy-tree-layout "^2.0.2"
-
 "@puppeteer/browsers@0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@puppeteer/browsers/-/browsers-0.5.0.tgz#1a1ee454b84a986b937ca2d93146f25a3fe8b670"
@@ -1678,7 +1665,7 @@ d3-zoom@3:
     d3-selection "2 - 3"
     d3-transition "2 - 3"
 
-d3@^7.0.0, d3@^7.4.0, d3@^7.8.2:
+d3@^7.4.0, d3@^7.8.2:
   version "7.8.2"
   resolved "https://registry.yarnpkg.com/d3/-/d3-7.8.2.tgz#2bdb3c178d095ae03b107a18837ae049838e372d"
   integrity sha512-WXty7qOGSHb7HR7CfOzwN1Gw04MUOzN8qh9ZUsvwycIMb4DYMpY9xczZ6jUorGtO6bR9BPMPaueIKwiDxu9uiQ==


### PR DESCRIPTION
## :bookmark_tabs: Summary

Since [Mermaid v9.4.0][1], the `@mermaid-js/mermaid-mindmap` package is no longer needed, since it has been integrated as part of the main mermaid package.

See: https://mermaid.js.org/syntax/mindmap.html#integrating-with-your-library-website
See: https://github.com/mermaid-js/mermaid/commit/71e4f1152b96fe716b156f1ab687fd01e724715b

[1]: https://github.com/mermaid-js/mermaid/releases/tag/v9.4.0

Removing this package decreases the size of `mermaid-cli`'s `dist/index.html` by about 8%!

### Before

```
dist/index.html                          5,241.86 kB │ gzip: 2,148.61 kB
```

### After

```
dist/index.html                          4,841.83 kB │ gzip: 2,020.65 kB
```

## :straight_ruler: Design Decisions

N/A

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
  - We already have mindmap tests!
- [x] :bookmark: targeted `master` branch
