### PR TITLE
Use `mermaid.render()` instead of `mermaid.run()` API to avoid removing whitespace from diagrams

### DIFF
--- a/src-test/test.js
+++ b/src-test/test.js
@@ -407,7 +407,7 @@ describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {
       const invalidMMDInput = 'this is not a valid mermaid file'
       expect(
         parseMMD(browser, invalidMMDInput, 'svg')
-      ).rejects.toThrow('Evaluation failed: Error: No diagram type detected matching given configuration for text: this is not a valid mermaid file')
+      ).rejects.toThrow('Evaluation failed: UnknownDiagramError: No diagram type detected matching given configuration for text: this is not a valid mermaid file')
     })
 
     describe.each(workflows)('testing workflow %s', (workflow) => {

--- a/src/index.js
+++ b/src/index.js
@@ -449,7 +449,7 @@ async function run (input, output, { puppeteerConfig = {}, quiet = false, output
     if (input && /\.(md|markdown)$/.test(input)) {
       const imagePromises = []
       for (const mermaidCodeblockMatch of definition.matchAll(mermaidChartsInMarkdownRegexGlobal)) {
-        const mermaidDefinition = mermaidCodeblockMatch[1]
+        const mermaidDefinition = mermaidCodeblockMatch[2]
 
         /** Output can be either a template image file, or a `.md` output file.
          *   If it is a template image file, use that to created numbered diagrams

--- a/test-positive/classDiagram-v2.mmd
+++ b/test-positive/classDiagram-v2.mmd
@@ -1,0 +1,9 @@
+---
+# This test is for issue https://github.com/mermaid-js/mermaid-cli/issues/532
+title: Empty class diagram v2 structs
+---
+classDiagram-v2
+    class Pancake {
+    }
+    class Waffle {
+    }


### PR DESCRIPTION
## :bookmark_tabs: Summary

Use the [`mermaid.render()`](https://mermaid.js.org/config/usage.html#api-usage) function instead of the `mermaid.run()` function to parse Mermaid diagram definitions directly, without going through HTML first.

  - fixes the issue of HTML removing newlines
    - Resolves https://github.com/mermaid-js/mermaid-cli/issues/532
  - means we get better error messages!

## :straight_ruler: Design Decisions

Currently, `mermaid-cli` renders mermaid diagrams by:

```mermaid
flowchart LR
    subgraph a ["Removes newlines!!!"]
        div["HTML &lt;div&gt;"]
    end
    MMD --> div["HTML &lt;div&gt;"]
    div -->|"mermaid.run()"| svg["HTML &lt;svg&gt;"]
```

However, when converting the mmd code to HTML `<div>`, newlines and whitespace formatting may get removed. For the majority of diagrams, this is no issue, but for some diagrams (e.g. `classDiagram`), whitespace does matter.

The mermaid API has a `mermaid.render()` function that we can use instead, which parses in mmd code directly, without having to go through a HTML element first:

```mermaid
flowchart LR
    MMD -->|"mermaid.render()"| svgText["SVG text"] -->svg["HTML &lt;svg&gt;"]
```

As an additional benefit, we get better error messages from Mermaid too!

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
