### PR TITLE
test: update flowchart3 test case

### DIFF
--- a/test-positive/flowchart3.mmd
+++ b/test-positive/flowchart3.mmd
@@ -4,4 +4,4 @@ graph TD
     B-->D(fa:fa-spinner);
     B-->E(A fa:fa-camera-retro perhaps?);
     %% Test whether embed <img> work correctly
-    D-->F("<img height='100' width='100' src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22%3E%3Ccircle cx=%2250%22 cy=%2250%22 r=%2240%22 stroke=%22black%22 stroke-width=%223%22 fill=%22red%22 /%3E%3C/svg%3E'/> <br/> Red Circle")
+    D-->F("<img height='100' width='100' src='data:image/svg+xml,%3Csvg viewBox=%220 0 100 100%22 xmlns=%22http://www.w3.org/2000/svg%22%3E%3Ccircle cx=%2250%22 cy=%2250%22 r=%2240%22 stroke=%22black%22 stroke-width=%223%22 fill=%22red%22 /%3E%3C/svg%3E'/> <br/> Red Circle")


### PR DESCRIPTION
## :bookmark_tabs: Summary

Mermaid v10.2.0 changed some behavior for `htmlLabels` with embedded SVG images. The `width=100%` is now set in the node CSS, which normally scales the images to the width of the text, but for this SVG, it seems to crop it. See https://github.com/mermaid-js/mermaid/issues/4455.

Setting a well-defined `viewBox` attribute to our SVG fixes this.

Resolves the visual regression discussed in https://github.com/mermaid-js/mermaid-cli/pull/541#issuecomment-1575789802

## :straight_ruler: Design Decisions

Thanks to @Valentine14th for finding and recommending this fix! I've credited them as a co-author.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
