### PR TITLE
Hide "Puppeteer old Headless deprecation warning"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -157,10 +157,19 @@ async function cli () {
     checkConfigFile(configFile)
     mermaidConfig = Object.assign(mermaidConfig, JSON.parse(fs.readFileSync(configFile, 'utf-8')))
   }
-  let puppeteerConfig = {}
+  // @ts-expect-error Setting headless to `1` is not officially supported
+  let puppeteerConfig = /** @type {import('puppeteer').PuppeteerLaunchOptions} */ ({
+    /*
+     * `headless: 1` is not officially supported, but setting this to any
+     * non-`true` truthy value doesn't change any behavior, but it hides the
+     * Puppeteer old Headless deprecation warning,
+     * see https://github.com/argos-ci/jest-puppeteer/issues/553#issuecomment-1561826456
+     */
+    headless: 1
+  })
   if (puppeteerConfigFile) {
     checkConfigFile(puppeteerConfigFile)
-    puppeteerConfig = JSON.parse(fs.readFileSync(puppeteerConfigFile, 'utf-8'))
+    puppeteerConfig = Object.assign(puppeteerConfig, JSON.parse(fs.readFileSync(puppeteerConfigFile, 'utf-8')))
   }
 
   // check cssFile


### PR DESCRIPTION
## :bookmark_tabs: Summary

Hide the "Puppeteer old Headless deprecation warning" that is printed in Puppeteer v19.11.0 or later, when `headless: "new"` is not used.

[1]: https://github.com/puppeteer/puppeteer/blob/159513c8dbe2c9f51aa37dbe531d52b5daf1e106/packages/puppeteer-core/src/node/ChromeLauncher.ts#L50
[2]: https://github.com/puppeteer/puppeteer/blob/159513c8dbe2c9f51aa37dbe531d52b5daf1e106/packages/puppeteer-core/src/node/ChromeLauncher.ts#L213-L215

Resolves https://github.com/mermaid-js/mermaid-cli/issues/544

## :straight_ruler: Design Decisions

Using `headless: "new"` is the official way of hiding this warning, but it currently isn't very stable in Puppeteer v19.11.0 (see https://github.com/mermaid-js/mermaid-cli/issues/544#issuecomment-1575808425), and we can't upgrade to Puppeteer v20 until mermaid-cli drops Node.JS v14 support.

Instead, we can set `headless: 1` as the default value. This is not officially supported (the official TypeScript types only allow `boolean | "new" | undefined`), but puppeteer only prints the warning if the [`headless` option is `true`][1], but it still uses headless mode if the [`headless` option is not `"new"` and truthy][2].

Thanks to @jt-nti for raising this potential fix in https://github.com/mermaid-js/mermaid-cli/issues/544#issuecomment-1602955907.
@jt-nti, would you mind if I give you a [`Co-authored-by` credit](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors), by adding a `Co-authored-by: James Taylor <3535067+jt-nti@users.noreply.github.com>` git trailer to my commit's description?

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch

## Todo before merging

- Give @jt-nti a few days to respond in case they're happy to credited as a `Co-author`.
