### PR TITLE
chore: remove unused resolution on `antlr4`

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,6 @@
     "vite-svg-loader": "^4.0.0",
     "yarn-upgrade-all": "^0.7.0"
   },
-  "resolutions": {
-    "antlr4": "~4.11.0"
-  },
   "files": [
     "src/",
     "dist/",


### PR DESCRIPTION
## :bookmark_tabs: Summary

Remove the `"resolution"` entry for `"antlr4"` in our `package.json` file.

This is no longer needed since the [v3.0.4](https://github.com/mermaid-js/zenuml-core/releases/tag/v3.0.4) release of https://www.npmjs.com/package/@zenuml/core.

## :straight_ruler: Design Decisions

This was originally added by https://github.com/mermaid-js/mermaid-cli/pull/566/commits/87aac7be1fd57e64ab78caa297210f593e8bcffe to work-around a bug in `@zenuml/core`.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
  - Tested by CI.
- [x] :bookmark: targeted `master` branch
