### PR TITLE
Fix TypeScript types to support `node16` and `bundler` `moduleResolution` modes

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,14 @@
   "engines": {
     "node": "^14.13 || >=16.0"
   },
-  "exports": "./src/index.js",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist-types/src/index.d.ts",
+        "default": "./src/index.js"
+      }
+    }
+  },
   "types": "./dist-types/src/index.d.ts",
   "scripts": {
     "prepare": "tsc && vite build",


### PR DESCRIPTION
## :bookmark_tabs: Summary

Currently, the TypeScript types for this module only support the `node10` TypeScript module resolution mode.

Now, `node10`, `node16` (ESM only), and `bundler` all work, according to https://arethetypeswrong.github.io/, see https://www.typescriptlang.org/docs/handbook/modules/theory.html#module-resolution

Resolves https://github.com/mermaid-js/mermaid-cli/issues/628
Resolves https://github.com/mermaid-js/mermaid-cli/issues/633

## :straight_ruler: Design Decisions

@andrewshawcare, I've listed you as a co-author for this commit since the content is from your recommended patch in https://github.com/mermaid-js/mermaid-cli/issues/633! Let me know if you're not comfortable with this, or if you'd prefer to make your own PR for this contribution!

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
  - Manually tested by running `yarn pack` and checking the contents with https://arethetypeswrong.github.io/:
  - ![image](https://github.com/mermaid-js/mermaid-cli/assets/19716675/e89d6378-d5cb-4ebf-893d-424fbc592ef9)
 
- [x] :bookmark: targeted `master` branch
