### PR TITLE
feat: add svgId option

### DIFF
--- a/src-test/test.js
+++ b/src-test/test.js
@@ -268,6 +268,14 @@ describe('mermaid-cli', () => {
     expectBytesAreFormat(await fs.readFile(expectedOutputFile), 'png')
   }, timeout)
 
+  test('the id of <svg> can be set', async () => {
+    const outputFile = 'test-positive/flowchart1.mmd.svg'
+    await fs.rm(outputFile, { force: true })
+    await promisify(execFile)('node', ['src/cli.js', '-i', 'test-positive/flowchart1.mmd', '-o', outputFile, '-I', 'custom-id'])
+
+    expect((await fs.readFile(outputFile)).toString()).toMatch(/^<svg[^>]+id="custom-id"/)
+  }, timeout)
+
   test.concurrent.each(['svg', 'png', 'pdf'])('should set red background to %s', async (format) => {
     await promisify(execFile)('node', [
       'src/cli.js', '-i', 'test-positive/flowchart1.mmd', '-o', `test-output/flowchart1-red-background.${format}`,


### PR DESCRIPTION
## :bookmark_tabs: Summary

Add a new option `-I, --svgId [svgId]` to set the id attribute of the `<svg>` element to be rendered.

This is useful when the output is used as a part of HTML, because Mermaid CSS pollutes the global CSS with the id.

## :straight_ruler: Design Decisions

`svgId || 'my-svg'` to use the old id as default. `||` instead of `??` to avoid empty id and for better compatibility.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
