### PR TITLE
Load all fonts before rendering

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -246,6 +246,8 @@ async function renderMermaid (browser, definition, outputFormat, { viewport, bac
       body.style.background = backgroundColor
     }, backgroundColor)
     const metadata = await page.$eval('#container', async (container, definition, mermaidConfig, myCSS, backgroundColor, svgId) => {
+      await Promise.all(Array.from(document.fonts, (font) => font.load()))
+
       /**
        * @typedef {Object} GlobalThisWithMermaid
        * We've already imported these modules in our `index.html` file, so that they


### PR DESCRIPTION
## :bookmark_tabs: Summary

Whether or not the used fonts have been loaded, affects the layout of the boxes that Mermaid renders. For consistent results, fonts must be loaded before the diagrams are rendered.

This was taken from [`mermaid-isomorphic`](https://github.com/remcohaszing/mermaid-isomorphic/blob/v2.1.2/src/mermaid-isomorphic.ts#L142). You may want to leverage that package instead.

Resolves #539

## :straight_ruler: Design Decisions

This preloads all fonts in the document.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
