### PR TITLE
perf: skip launching puppeteer when not needed

### DIFF
--- a/test-positive/mermaidless-markdown-file.md
+++ b/test-positive/mermaidless-markdown-file.md
@@ -1,0 +1,3 @@
+# This markdown file has no mermaid code blocks in it
+
+This markdown file purposely has no mermaid code blocks in it.


### PR DESCRIPTION
## :bookmark_tabs: Summary

Skip launching puppeteer until it's actually needed.

Running mermaid-cli on a markdown file without any mermaid code blocks shouldn't launch puppeteer, if it's unnecessary.

Resolves https://github.com/mermaid-js/mermaid-cli/issues/694

## :straight_ruler: Design Decisions

N/A

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
