### PR TITLE
perf: skip inlining fonts

### DIFF
--- a/DockerfileBuild
+++ b/DockerfileBuild
@@ -1,4 +1,4 @@
-FROM node:alpine AS build
+FROM node:18.20-alpine3.19 AS build
 
 ENV CHROME_BIN="/usr/bin/chromium-browser" \
     PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
@@ -12,7 +12,7 @@ COPY . /app/
 RUN yarn \
     && yarn pack
 
-FROM node:alpine AS mermaid-cli-current
+FROM node:18.20-alpine3.19 AS mermaid-cli-current
 
 WORKDIR /app
 

--- a/index.html
+++ b/index.html
@@ -5,11 +5,11 @@
     <script type="module">
       // don't import minified CSS files (e.g. `*.min.css`), since that actually
       // makes the dist/index.html slightly larger!
-      import faBrands from "@fortawesome/fontawesome-free/css/brands.css"
-      import faRegular from "@fortawesome/fontawesome-free/css/regular.css"
-      import faSolid from "@fortawesome/fontawesome-free/css/solid.css"
-      import fontawesome from "@fortawesome/fontawesome-free/css/fontawesome.css"
-      import katex from "katex/dist/katex.css"
+      import "@fortawesome/fontawesome-free/css/brands.css"
+      import "@fortawesome/fontawesome-free/css/regular.css"
+      import "@fortawesome/fontawesome-free/css/solid.css"
+      import "@fortawesome/fontawesome-free/css/fontawesome.css"
+      import "katex/dist/katex.css"
 
       import zenuml from "@mermaid-js/mermaid-zenuml"
 

--- a/package.json
+++ b/package.json
@@ -42,8 +42,6 @@
     "standard": "^17.0.0",
     "typescript": "^5.0.1-rc",
     "vite": "^4.0.3",
-    "vite-plugin-singlefile": "^0.13.1",
-    "vite-svg-loader": "^4.0.0",
     "yarn-upgrade-all": "^0.7.0"
   },
   "files": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,28 @@
 import { defineConfig } from "vite"
-import { viteSingleFile } from "vite-plugin-singlefile"
-import svgLoader from 'vite-svg-loader'
 
 export default defineConfig({
+  base: './',
   plugins: [
-    // bundle everything into a single `index.html`
-    viteSingleFile(),
-    // unsure if this is working properly for fontawesome fonts
-    svgLoader(),
-  ],
-})
+    {
+      name: 'IIFE-converter',
+      config(currentConfig, _unused) {
+        return {
+          ...currentConfig,
+          build: {
+            ...currentConfig.build,
+            rollupOptions: {
+              ...currentConfig.build?.rollupOptions,
+              output: {
+                ...currentConfig.build?.rollupOptions?.output,
+                format: 'iife',
+              }
+            }
+          }
+        };
+      },
+      transformIndexHtml(html) {
+        return html.replace('<script type="module" crossorigin', '<script')
+      }
+    }
+  ]
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -213,11 +213,6 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.11.tgz#68bb07ab3d380affa9a3f96728df07969645d2d9"
   integrity sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==
 
-"@babel/parser@^7.16.4":
-  version "7.20.3"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.3.tgz#5358cf62e380cf69efcb87a7bb922ff88bfac6e2"
-  integrity sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==
-
 "@babel/parser@^7.20.15", "@babel/parser@^7.21.3":
   version "7.22.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.7.tgz#df8cf085ce92ddbdbf668a7f186ce848c9036cae"
@@ -960,11 +955,6 @@
   dependencies:
     "@tanstack/virtual-core" "3.1.3"
 
-"@trysound/sax@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
-  integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
-
 "@tsconfig/node14@^14.1.0":
   version "14.1.2"
   resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-14.1.2.tgz#ed84879e927a2f12ae8bb020baa990bd4cc3dabb"
@@ -1122,16 +1112,6 @@
     estree-walker "^2.0.2"
     source-map-js "^1.0.2"
 
-"@vue/compiler-core@3.2.44":
-  version "3.2.44"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.2.44.tgz#9ce3044db28b4b3d5de20cf345ad952f9303e91f"
-  integrity sha512-TwzeVSnaklb8wIvMtwtkPkt9wnU+XD70xJ7N9+eIHtjKAG7OoZttm+14ZL6vWOL+2RcMtSZ+cYH+gvkUqsrmSQ==
-  dependencies:
-    "@babel/parser" "^7.16.4"
-    "@vue/shared" "3.2.44"
-    estree-walker "^2.0.2"
-    source-map "^0.6.1"
-
 "@vue/compiler-core@3.3.4":
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.3.4.tgz#7fbf591c1c19e1acd28ffd284526e98b4f581128"
@@ -1141,14 +1121,6 @@
     "@vue/shared" "3.3.4"
     estree-walker "^2.0.2"
     source-map-js "^1.0.2"
-
-"@vue/compiler-dom@3.2.44":
-  version "3.2.44"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.2.44.tgz#0fac337a8a6b3cae586aa8cac62e418aa4c79a83"
-  integrity sha512-wPDR+gOn2Qi7SudPJ+gE62vuO/aKXIiIFALvHpztXmDdbAHGy3CDfmBgOGchTgTlSeDJHe9olEMkgOdmyXTjUg==
-  dependencies:
-    "@vue/compiler-core" "3.2.44"
-    "@vue/shared" "3.2.44"
 
 "@vue/compiler-dom@3.3.4":
   version "3.3.4"
@@ -1174,30 +1146,6 @@
     postcss "^8.1.10"
     source-map-js "^1.0.2"
 
-"@vue/compiler-sfc@^3.2.20":
-  version "3.2.44"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.2.44.tgz#3cc87afdd39d1d9294b45bdd3402ef405d2b0938"
-  integrity sha512-8cFZcUWlrtnfM/GlRwYJdlfgbEOy0OZ/osLDU3h/wJu24HuYAc7QIML1USaKqiZzkjOaTd4y8mvYvcWXq3o5dA==
-  dependencies:
-    "@babel/parser" "^7.16.4"
-    "@vue/compiler-core" "3.2.44"
-    "@vue/compiler-dom" "3.2.44"
-    "@vue/compiler-ssr" "3.2.44"
-    "@vue/reactivity-transform" "3.2.44"
-    "@vue/shared" "3.2.44"
-    estree-walker "^2.0.2"
-    magic-string "^0.25.7"
-    postcss "^8.1.10"
-    source-map "^0.6.1"
-
-"@vue/compiler-ssr@3.2.44":
-  version "3.2.44"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.2.44.tgz#efba77f4df4ea1727752637764f9d10498daa7df"
-  integrity sha512-tAkUFLgvxds3l5KPyAH77OIYrEeLngNYQfWA9GocHiy2nlyajjqAH/Jq93Bq29Y20GeJzblmRp9DVYCVkJ5Rsw==
-  dependencies:
-    "@vue/compiler-dom" "3.2.44"
-    "@vue/shared" "3.2.44"
-
 "@vue/compiler-ssr@3.3.4":
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.3.4.tgz#9d1379abffa4f2b0cd844174ceec4a9721138777"
@@ -1210,17 +1158,6 @@
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.5.0.tgz#98b99425edee70b4c992692628fa1ea2c1e57d07"
   integrity sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q==
-
-"@vue/reactivity-transform@3.2.44":
-  version "3.2.44"
-  resolved "https://registry.yarnpkg.com/@vue/reactivity-transform/-/reactivity-transform-3.2.44.tgz#dab1175ee8ef1fa7e9d3d9ffe177ed03f70d4021"
-  integrity sha512-WGbEiXaS2qAOTS9Z3kKk2Nk4bi8OUl73Sih+h0XV9RTUATnaJSEQedveHUDQnHyXiZwyBMKosrxJg8aThHO/rw==
-  dependencies:
-    "@babel/parser" "^7.16.4"
-    "@vue/compiler-core" "3.2.44"
-    "@vue/shared" "3.2.44"
-    estree-walker "^2.0.2"
-    magic-string "^0.25.7"
 
 "@vue/reactivity-transform@3.3.4":
   version "3.3.4"
@@ -1264,11 +1201,6 @@
   dependencies:
     "@vue/compiler-ssr" "3.3.4"
     "@vue/shared" "3.3.4"
-
-"@vue/shared@3.2.44":
-  version "3.2.44"
-  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.44.tgz#d180eae83de86a48a3a0b6aaded546683443ca57"
-  integrity sha512-mGZ44bnn0zpZ36nXtxbrBPno43yr96wjQE1dBEKS1Sieugt27HS4OGZVBRIgsdGzosB7vqZAvu0ttu1FDVdolA==
 
 "@vue/shared@3.3.4":
   version "3.3.4"
@@ -1562,11 +1494,6 @@ bl@^4.0.3:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-boolbase@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
-  integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -1790,7 +1717,7 @@ color-string@^1.5.5:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
 
-commander@7, commander@^7.2.0:
+commander@7:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
@@ -1872,49 +1799,10 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-css-select@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
-  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
-  dependencies:
-    boolbase "^1.0.0"
-    css-what "^6.1.0"
-    domhandler "^5.0.2"
-    domutils "^3.0.1"
-    nth-check "^2.0.1"
-
-css-tree@^2.2.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-2.3.1.tgz#10264ce1e5442e8572fc82fbe490644ff54b5c20"
-  integrity sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==
-  dependencies:
-    mdn-data "2.0.30"
-    source-map-js "^1.0.1"
-
-css-tree@~2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-2.2.1.tgz#36115d382d60afd271e377f9c5f67d02bd48c032"
-  integrity sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==
-  dependencies:
-    mdn-data "2.0.28"
-    source-map-js "^1.0.1"
-
-css-what@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
-  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
-
 cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
-
-csso@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/csso/-/csso-5.0.5.tgz#f9b7fe6cc6ac0b7d90781bb16d5e9874303e2ca6"
-  integrity sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==
-  dependencies:
-    css-tree "~2.2.0"
 
 csstype@^3.1.1:
   version "3.1.2"
@@ -2330,45 +2218,15 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-serializer@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
-  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
-  dependencies:
-    domelementtype "^2.3.0"
-    domhandler "^5.0.2"
-    entities "^4.2.0"
-
 dom-to-image-more@^2.13.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/dom-to-image-more/-/dom-to-image-more-2.16.0.tgz#ffafe86e4561b3a0ecce3b18ddf4ec88fd2ca576"
   integrity sha512-RyjtkaM/zVy90uJ20lT+/G7MwBZx6l/ePliq5CQOeAnPeew7aUGS6IqRWBkHpstU+POmhaKA8A9H9qf476gisQ==
 
-domelementtype@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
-  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
-
-domhandler@^5.0.1, domhandler@^5.0.2:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
-  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
-  dependencies:
-    domelementtype "^2.3.0"
-
 dompurify@^3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.0.5.tgz#eb3d9cfa10037b6e73f32c586682c4b2ab01fbed"
   integrity sha512-F9e6wPGtY+8KNMRAVfxeCOHU0/NPWMSENNq4pQctuXRqqdEPW7q3CrLbR5Nse044WwacyjHGOMlvNsBe1y6z9A==
-
-domutils@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.0.1.tgz#696b3875238338cb186b6c0612bd4901c89a4f1c"
-  integrity sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==
-  dependencies:
-    dom-serializer "^2.0.0"
-    domelementtype "^2.3.0"
-    domhandler "^5.0.1"
 
 electron-to-chromium@^1.4.118:
   version "1.4.129"
@@ -2395,11 +2253,6 @@ end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   resolved "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz"
   dependencies:
     once "^1.4.0"
-
-entities@^4.2.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
-  integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -4058,13 +3911,6 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-magic-string@^0.25.7:
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
-  integrity sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==
-  dependencies:
-    sourcemap-codec "^1.4.8"
-
 magic-string@^0.30.0:
   version "0.30.1"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.1.tgz#ce5cd4b0a81a5d032bd69aab4522299b2166284d"
@@ -4115,16 +3961,6 @@ mdast-util-to-string@^3.1.0:
   integrity sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==
   dependencies:
     "@types/mdast" "^3.0.0"
-
-mdn-data@2.0.28:
-  version "2.0.28"
-  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.28.tgz#5ec48e7bef120654539069e1ae4ddc81ca490eba"
-  integrity sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==
-
-mdn-data@2.0.30:
-  version "2.0.30"
-  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.30.tgz#ce4df6f80af6cfbe218ecd5c552ba13c4dfa08cc"
-  integrity sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -4457,13 +4293,6 @@ npm-run-path@^4.0.1:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
-
-nth-check@^2.0.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
-  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
-  dependencies:
-    boolbase "^1.0.0"
 
 object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
@@ -5143,7 +4972,7 @@ sonic-boom@^3.7.0:
   dependencies:
     atomic-sleep "^1.0.0"
 
-source-map-js@^1.0.1, source-map-js@^1.0.2:
+source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
@@ -5160,11 +4989,6 @@ source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
-sourcemap-codec@^1.4.8:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
-  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 split2@^4.0.0:
   version "4.2.0"
@@ -5360,18 +5184,6 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
-
-svgo@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/svgo/-/svgo-3.0.2.tgz#5e99eeea42c68ee0dc46aa16da093838c262fe0a"
-  integrity sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==
-  dependencies:
-    "@trysound/sax" "0.2.0"
-    commander "^7.2.0"
-    css-select "^5.1.0"
-    css-tree "^2.2.1"
-    csso "^5.0.5"
-    picocolors "^1.0.0"
 
 tailwindcss@^3.2.4:
   version "3.3.2"
@@ -5610,21 +5422,6 @@ version-guard@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/version-guard/-/version-guard-1.1.1.tgz#7a6e87a1babff1b43d6a7b0fd239731e278262fa"
   integrity sha512-MGQLX89UxmYHgDvcXyjBI0cbmoW+t/dANDppNPrno64rYr8nH4SHSuElQuSYdXGEs0mUzdQe1BY+FhVPNsAmJQ==
-
-vite-plugin-singlefile@^0.13.1:
-  version "0.13.5"
-  resolved "https://registry.yarnpkg.com/vite-plugin-singlefile/-/vite-plugin-singlefile-0.13.5.tgz#9465dbb0b06afb2a73600a50fcce4b51c8d10999"
-  integrity sha512-y/aRGh8qHmw2f1IhaI/C6PJAaov47ESYDvUv1am1YHMhpY+19B5k5Odp8P+tgs+zhfvak6QB1ykrALQErEAo7g==
-  dependencies:
-    micromatch "^4.0.5"
-
-vite-svg-loader@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/vite-svg-loader/-/vite-svg-loader-4.0.0.tgz#1cec4337dba3c23ab13bcabb111896e251b047ac"
-  integrity sha512-0MMf1yzzSYlV4MGePsLVAOqXsbF5IVxbn4EEzqRnWxTQl8BJg/cfwIzfQNmNQxZp5XXwd4kyRKF1LytuHZTnqA==
-  dependencies:
-    "@vue/compiler-sfc" "^3.2.20"
-    svgo "^3.0.2"
 
 vite@^4.0.3:
   version "4.5.3"


### PR DESCRIPTION
## :bookmark_tabs: Summary

Currently, when we run `yarn` to build the `dist/index.html`, we're inlining all the JavaScript, CSS, and FontAwesome/KaTeX fonts into one massive `dist/index.html` file.

However, this isn't very efficient, since the fonts are stored in the `dist/index.html` file as base64, which adds a lot of storage and parsing time.

Disabling this makes the code about 10% faster for me (tests run in 110s instead of 120s), and the size on the bundle went from 4MiB to 3.5MiB.

## :straight_ruler: Design Decisions

We were previously using the `vite-plugin-singlefile` tool, since Puppeteer can't import ESM JavaScript modules, which the `@mermaid-js/mermaid-zenuml` package is.

However, I wrote a super tiny Vite plugin to output all JavaScript in the IIFE format (and changed `index.html` to import the file as an IFFE), and it all seems to work fine!

## `npm pack` output

### Before

One massive `dist/index.html` file that is `4.8 MB`!

```
npm notice
npm notice 📦  @mermaid-js/mermaid-cli@10.9.1
npm notice === Tarball Contents ===
npm notice 1.1kB   LICENSE
npm notice 7.3kB   README.md
npm notice 64B     dist-types/src/cli.d.ts
npm notice 103B    dist-types/src/cli.d.ts.map
npm notice 4.8kB   dist-types/src/index.d.ts
npm notice 774B    dist-types/src/index.d.ts.map
npm notice 747.9kB dist/assets/fa-brands-400-a3b98177.svg
npm notice 144.7kB dist/assets/fa-regular-400-be0a0849.svg
npm notice 919.0kB dist/assets/fa-solid-900-9674eb1b.svg
npm notice 4.8MB   dist/index.html
npm notice 1.6kB   package.json
npm notice 177B    src/cli.js
npm notice 20.0kB  src/index.js
npm notice === Tarball Details ===
npm notice name:          @mermaid-js/mermaid-cli
npm notice version:       10.9.1
npm notice filename:      mermaid-js-mermaid-cli-10.9.1.tgz
npm notice package size:  3.0 MB
npm notice unpacked size: 6.6 MB
npm notice shasum:        1b4be5539206db506c264a6c3162dc51ec6e0ff2
npm notice integrity:     sha512-SEo2XQtMVWP+A[...]oMt2vBpx+ZGZw==
npm notice total files:   13
npm notice
```

### After

Lots of small `dist/asserts/*` font files that take up less space overall.

```
npm notice
npm notice 📦  @mermaid-js/mermaid-cli@10.9.1
npm notice === Tarball Contents ===
npm notice 1.1kB   LICENSE
npm notice 7.3kB   README.md
npm notice 64B     dist-types/src/cli.d.ts
npm notice 103B    dist-types/src/cli.d.ts.map
npm notice 4.8kB   dist-types/src/index.d.ts
npm notice 774B    dist-types/src/index.d.ts.map
npm notice 76.7kB  dist/assets/fa-brands-400-8ea87917.woff2
npm notice 747.9kB dist/assets/fa-brands-400-a3b98177.svg
npm notice 134.0kB dist/assets/fa-brands-400-cda59d6e.ttf
npm notice 134.3kB dist/assets/fa-brands-400-e4299464.eot
npm notice 90.0kB  dist/assets/fa-brands-400-f9217f66.woff
npm notice 34.0kB  dist/assets/fa-regular-400-79d08806.eot
npm notice 144.7kB dist/assets/fa-regular-400-be0a0849.svg
npm notice 16.3kB  dist/assets/fa-regular-400-cb9e9e69.woff
npm notice 13.2kB  dist/assets/fa-regular-400-e42a8844.woff2
npm notice 33.7kB  dist/assets/fa-regular-400-e8711bbb.ttf
npm notice 101.6kB dist/assets/fa-solid-900-3f6d3488.woff
npm notice 203.0kB dist/assets/fa-solid-900-373c04fd.eot
npm notice 919.0kB dist/assets/fa-solid-900-9674eb1b.svg
npm notice 78.3kB  dist/assets/fa-solid-900-9834b82a.woff2
npm notice 202.7kB dist/assets/fa-solid-900-af639750.ttf
npm notice 1.4MB   dist/assets/index-594c3b64.js
npm notice 28.1kB  dist/assets/KaTeX_AMS-Regular-0cdd387c.woff2
npm notice 33.5kB  dist/assets/KaTeX_AMS-Regular-30da91e8.woff
npm notice 63.6kB  dist/assets/KaTeX_AMS-Regular-68534840.ttf
npm notice 7.7kB   dist/assets/KaTeX_Caligraphic-Bold-1ae6bd74.woff
npm notice 12.4kB  dist/assets/KaTeX_Caligraphic-Bold-07d8e303.ttf
npm notice 6.9kB   dist/assets/KaTeX_Caligraphic-Bold-de7701e4.woff2
npm notice 6.9kB   dist/assets/KaTeX_Caligraphic-Regular-5d53e70a.woff2
npm notice 7.7kB   dist/assets/KaTeX_Caligraphic-Regular-3398dd02.woff
npm notice 12.3kB  dist/assets/KaTeX_Caligraphic-Regular-ed0b7437.ttf
npm notice 13.3kB  dist/assets/KaTeX_Fraktur-Bold-9be7ceb8.woff
npm notice 19.6kB  dist/assets/KaTeX_Fraktur-Bold-9163df9c.ttf
npm notice 11.3kB  dist/assets/KaTeX_Fraktur-Bold-74444efd.woff2
npm notice 19.6kB  dist/assets/KaTeX_Fraktur-Regular-1e6f9579.ttf
npm notice 13.2kB  dist/assets/KaTeX_Fraktur-Regular-5e28753b.woff
npm notice 11.3kB  dist/assets/KaTeX_Fraktur-Regular-51814d27.woff2
npm notice 25.3kB  dist/assets/KaTeX_Main-Bold-0f60d1b8.woff2
npm notice 51.3kB  dist/assets/KaTeX_Main-Bold-138ac28d.ttf
npm notice 29.9kB  dist/assets/KaTeX_Main-Bold-c76c5d69.woff
npm notice 33.0kB  dist/assets/KaTeX_Main-BoldItalic-70ee1f64.ttf
npm notice 16.8kB  dist/assets/KaTeX_Main-BoldItalic-99cd42a3.woff2
npm notice 19.4kB  dist/assets/KaTeX_Main-BoldItalic-a6f7ec0d.woff
npm notice 33.6kB  dist/assets/KaTeX_Main-Italic-0d85ae7c.ttf
npm notice 17.0kB  dist/assets/KaTeX_Main-Italic-97479ca6.woff2
npm notice 19.7kB  dist/assets/KaTeX_Main-Italic-f1d6ef86.woff
npm notice 26.3kB  dist/assets/KaTeX_Main-Regular-c2342cd8.woff2
npm notice 30.8kB  dist/assets/KaTeX_Main-Regular-c6368d87.woff
npm notice 53.6kB  dist/assets/KaTeX_Main-Regular-d0332f52.ttf
npm notice 18.7kB  dist/assets/KaTeX_Math-BoldItalic-850c0af5.woff
npm notice 16.4kB  dist/assets/KaTeX_Math-BoldItalic-dc47344d.woff2
npm notice 31.2kB  dist/assets/KaTeX_Math-BoldItalic-f9377ab0.ttf
npm notice 16.4kB  dist/assets/KaTeX_Math-Italic-7af58c5e.woff2
npm notice 18.7kB  dist/assets/KaTeX_Math-Italic-8a8d2445.woff
npm notice 31.3kB  dist/assets/KaTeX_Math-Italic-08ce98e5.ttf
npm notice 24.5kB  dist/assets/KaTeX_SansSerif-Bold-1ece03f7.ttf
npm notice 12.2kB  dist/assets/KaTeX_SansSerif-Bold-e99ae511.woff2
npm notice 14.4kB  dist/assets/KaTeX_SansSerif-Bold-ece03cfd.woff
npm notice 12.0kB  dist/assets/KaTeX_SansSerif-Italic-00b26ac8.woff2
npm notice 14.1kB  dist/assets/KaTeX_SansSerif-Italic-91ee6750.woff
npm notice 22.4kB  dist/assets/KaTeX_SansSerif-Italic-3931dd81.ttf
npm notice 12.3kB  dist/assets/KaTeX_SansSerif-Regular-11e4dc8a.woff
npm notice 10.3kB  dist/assets/KaTeX_SansSerif-Regular-68e8c73e.woff2
npm notice 19.4kB  dist/assets/KaTeX_SansSerif-Regular-f36ea897.ttf
npm notice 16.6kB  dist/assets/KaTeX_Script-Regular-1c67f068.ttf
npm notice 9.6kB   dist/assets/KaTeX_Script-Regular-036d4e95.woff2
npm notice 10.6kB  dist/assets/KaTeX_Script-Regular-d96cdf2b.woff
npm notice 5.5kB   dist/assets/KaTeX_Size1-Regular-6b47c401.woff2
npm notice 12.2kB  dist/assets/KaTeX_Size1-Regular-95b6d2f1.ttf
npm notice 6.5kB   dist/assets/KaTeX_Size1-Regular-c943cc98.woff
npm notice 6.2kB   dist/assets/KaTeX_Size2-Regular-2014c523.woff
npm notice 11.5kB  dist/assets/KaTeX_Size2-Regular-a6b2099f.ttf
npm notice 5.2kB   dist/assets/KaTeX_Size2-Regular-d04c5421.woff2
npm notice 4.4kB   dist/assets/KaTeX_Size3-Regular-6ab6b62e.woff
npm notice 7.6kB   dist/assets/KaTeX_Size3-Regular-500e04d5.ttf
npm notice 6.0kB   dist/assets/KaTeX_Size4-Regular-99f9c675.woff
npm notice 4.9kB   dist/assets/KaTeX_Size4-Regular-a4af7d41.woff2
npm notice 10.4kB  dist/assets/KaTeX_Size4-Regular-c647367d.ttf
npm notice 13.6kB  dist/assets/KaTeX_Typewriter-Regular-71d517d6.woff2
npm notice 16.0kB  dist/assets/KaTeX_Typewriter-Regular-e14fed02.woff
npm notice 27.6kB  dist/assets/KaTeX_Typewriter-Regular-f01f3e87.ttf
npm notice 140B    dist/index.html
npm notice 1.5kB   package.json
npm notice 177B    src/cli.js
npm notice 20.0kB  src/index.js
npm notice === Tarball Details ===
npm notice name:          @mermaid-js/mermaid-cli
npm notice version:       10.9.1
npm notice filename:      mermaid-js-mermaid-cli-10.9.1.tgz
npm notice package size:  2.5 MB
npm notice unpacked size: 5.4 MB
npm notice shasum:        e3269cdfbc7a64283b60ad8820c7becb719b1461
npm notice integrity:     sha512-JvuJOhfGsVLxy[...]ce9fDIZ9Ee69Q==
npm notice total files:   85
npm notice
```

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
