### PR TITLE
fix: add some checks for FontAwesome fonts to load

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -249,13 +249,18 @@ async function renderMermaid (browser, definition, outputFormat, { viewport, bac
     }
     const mermaidHTMLPath = path.join(__dirname, '..', 'dist', 'index.html')
     await page.goto(url.pathToFileURL(mermaidHTMLPath).href)
-    await page.$eval('body', (body, backgroundColor) => {
-      body.style.background = backgroundColor
-    }, backgroundColor)
-    await page.addScriptTag({ path: mermaidIIFEPath })
-    const metadata = await page.$eval('#container', async (container, definition, mermaidConfig, myCSS, backgroundColor, svgId) => {
-      await Promise.all(Array.from(document.fonts, (font) => font.load()))
 
+    await Promise.all([
+      page.$eval('style', async () => {
+        await Promise.all(Array.from(document.fonts, (font) => font.load()))
+      }),
+      page.$eval('body', (body, backgroundColor) => {
+        body.style.background = backgroundColor
+      }, backgroundColor),
+      page.addScriptTag({ path: mermaidIIFEPath })
+    ])
+
+    const metadata = await page.$eval('#container', async (container, definition, mermaidConfig, myCSS, backgroundColor, svgId) => {
       /**
        * @typedef {Object} GlobalThisWithMermaid
        * We've already imported these modules in our `index.html` file (or by running `page.addScriptTag`),


### PR DESCRIPTION
## :bookmark_tabs: Summary

Sometimes, `await Promise.all(Array.from(document.fonts, (font) => font.load()))` (added in https://github.com/mermaid-js/mermaid-cli/commit/c179bc1f7ad0066f331217cb2dbea0b8aa9a1d1c) doesn't actually wait for fonts to load.

I can't seem to reproduce this on my computer, but it does occasionally happen in GitHub CI (I've seen it happen with Percy).

I'm not exactly sure why this is, (maybe it doesn't include actually applying the fonts?), but just to be safe, I've added some explicit `await document.fonts.read` checks, and even added a warning if Font Awesome is not loaded, and maybe that might help?

![flowchart3-run](https://github.com/mermaid-js/mermaid-cli/assets/19716675/93ee5862-a8d4-4b2c-8076-28b153ab351d)

## :straight_ruler: Design Decisions

N/A

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
