### PR TITLE
Support using stdout

### DIFF
--- a/src-test/test.js
+++ b/src-test/test.js
@@ -177,6 +177,26 @@ describe('mermaid-cli', () => {
     expect(stderr).not.toContain('No input file specified, reading from stdin.')
   }, timeout)
 
+  test('should warn when outputing to stdout with missing --outputFormat', async () => {
+    const execFilePromise = promisify(execFile)('node', ['src/cli.js', '--output', '-'])
+    await promisify(pipeline)(
+      createReadStream('test-positive/flowchart1.mmd'),
+      execFilePromise.child.stdin
+    )
+    const { stderr } = await execFilePromise
+    expect(stderr).toContain('No output format specified, using svg.')
+  }, timeout)
+
+  test('should not warn when outputing to stdout with --outputFormat', async () => {
+    const execFilePromise = promisify(execFile)('node', ['src/cli.js', '--output', '-', '--outputFormat', 'svg'])
+    await promisify(pipeline)(
+      createReadStream('test-positive/flowchart1.mmd'),
+      execFilePromise.child.stdin
+    )
+    const { stderr } = await execFilePromise
+    expect(stderr).not.toContain('No output format specified, using svg.')
+  }, timeout)
+
   test('should error on mermaid syntax error', async () => {
     await expect(
       compileDiagram('test-negative', 'invalid.expect-error.mmd', 'svg')

--- a/src/index.js
+++ b/src/index.js
@@ -167,7 +167,7 @@ async function cli () {
   }
 
   const outputDir = path.dirname(output)
-  if (!fs.existsSync(outputDir)) {
+  if (output !== '/dev/stdout' && !fs.existsSync(outputDir)) {
     error(`Output directory "${outputDir}/" doesn't exist`)
   }
 
@@ -253,7 +253,7 @@ async function parseMMD (browser, definition, outputFormat, opt) {
 async function renderMermaid (browser, definition, outputFormat, { viewport, backgroundColor = 'white', mermaidConfig = {}, myCSS, pdfFit, svgId } = {}) {
   const page = await browser.newPage()
   page.on('console', (msg) => {
-    console.log(msg.text())
+    console.warn(msg.text())
   })
   try {
     if (viewport) {

--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,7 @@ async function cli () {
     .addOption(new Option('-w, --width [width]', 'Width of the page').argParser(parseCommanderInt).default(800))
     .addOption(new Option('-H, --height [height]', 'Height of the page').argParser(parseCommanderInt).default(600))
     .option('-i, --input <input>', 'Input mermaid file. Files ending in .md will be treated as Markdown and all charts (e.g. ```mermaid (...)``` or :::mermaid (...):::) will be extracted and generated. Use `-` to read from stdin.')
-    .option('-o, --output [output]', 'Output file. It should be either md, svg, png or pdf. Optional. Default: input + ".svg"')
+    .option('-o, --output [output]', 'Output file. It should be either md, svg, png, pdf or use `-` to output to stdout. Optional. Default: input + ".svg"')
     .addOption(new Option('-e, --outputFormat [format]', 'Output format for the generated image.').choices(['svg', 'png', 'pdf']).default(null, 'Loaded from the output file extension'))
     .addOption(new Option('-b, --backgroundColor [backgroundColor]', 'Background color for pngs/svgs (not pdfs). Example: transparent, red, \'#F0F0F0\'.').default('white'))
     .option('-c, --configFile [configFile]', 'JSON configuration file for mermaid.')
@@ -150,13 +150,26 @@ async function cli () {
     } else {
       output = input ? (`${input}.svg`) : 'out.svg'
     }
-  }
-  if (!/\.(?:svg|png|pdf|md|markdown)$/.test(output)) {
+  } else if (output === '-') {
+    // `--output -` means write to stdout.
+    output = '/dev/stdout'
+    quiet = true
+
+    if (!outputFormat) {
+      outputFormat = 'svg'
+      warn('No output format specified, using svg. ' +
+        'If you want to specify an output format and supress this warning, ' +
+        'please use `-e <format>.` '
+      )
+    }
+  } else if (!/\.(?:svg|png|pdf|md|markdown)$/.test(output)) {
     error('Output file must end with ".md"/".markdown", ".svg", ".png" or ".pdf"')
   }
-  const outputDir = path.dirname(output)
-  if (!fs.existsSync(outputDir)) {
-    error(`Output directory "${outputDir}/" doesn't exist`)
+  if (output) {
+    const outputDir = path.dirname(output)
+    if (!fs.existsSync(outputDir)) {
+      error(`Output directory "${outputDir}/" doesn't exist`)
+    }
   }
 
   // check config files
@@ -390,7 +403,7 @@ function markdownImage ({ url, title, alt }) {
  * path to a markdown file containing mermaid.
  * If this is a string, loads the mermaid definition from the given file.
  * If this is `undefined`, loads the mermaid definition from stdin.
- * @param {`${string}.${"md" | "markdown" | "svg" | "png" | "pdf"}`} output - Path to the output file.
+ * @param {`${string}.${"md" | "markdown" | "svg" | "png" | "pdf"}` | "/dev/stdout"} output - Path to the output file.
  * @param {Object} [opts] - Options
  * @param {import("puppeteer").LaunchOptions} [opts.puppeteerConfig] - Puppeteer launch options.
  * @param {boolean} [opts.quiet] - If set, suppress log output.
@@ -437,6 +450,10 @@ async function run (input, output, { puppeteerConfig = {}, quiet = false, output
 
     const definition = await getInputData(input)
     if (input && /\.(md|markdown)$/.test(input)) {
+      if (output === '/dev/stdout') {
+        throw new Error('Cannot use `stdout` with markdown input')
+      }
+
       const imagePromises = []
       for (const mermaidCodeblockMatch of definition.matchAll(mermaidChartsInMarkdownRegexGlobal)) {
         if (browser === undefined) {
@@ -497,7 +514,9 @@ async function run (input, output, { puppeteerConfig = {}, quiet = false, output
       info('Generating single mermaid chart')
       browser = await puppeteer.launch(puppeteerConfig)
       const data = await parseMMD(browser, definition, outputFormat, parseMMDOptions)
-      await fs.promises.writeFile(output, data)
+      await output !== '/dev/stdout'
+        ? fs.promises.writeFile(output, data)
+        : process.stdout.write(data)
     }
   } finally {
     await browser?.close?.()

--- a/src/index.js
+++ b/src/index.js
@@ -165,11 +165,10 @@ async function cli () {
   } else if (!/\.(?:svg|png|pdf|md|markdown)$/.test(output)) {
     error('Output file must end with ".md"/".markdown", ".svg", ".png" or ".pdf"')
   }
-  if (output) {
-    const outputDir = path.dirname(output)
-    if (!fs.existsSync(outputDir)) {
-      error(`Output directory "${outputDir}/" doesn't exist`)
-    }
+
+  const outputDir = path.dirname(output)
+  if (!fs.existsSync(outputDir)) {
+    error(`Output directory "${outputDir}/" doesn't exist`)
   }
 
   // check config files


### PR DESCRIPTION
## :bookmark_tabs: Summary

Support writing to `stdout` if the user explicitly specifies `-`.  In case of no output format, it is assumed to be `svg` and a warning is displayed.

Resolves #683

## :straight_ruler: Design Decisions

For the sake of making the code more readable, I'm using explicit `'/dev/stdout'`.  This is just a personal preference and   doesn't have anything to do with the platform.

I have also disabled writing to `stdout` if the input is markdown.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
