### PR TITLE
build: use `node:18.20-alpine3.19` in Docker build

### DIFF
--- a/DockerfileBuild
+++ b/DockerfileBuild
@@ -1,4 +1,4 @@
-FROM node:alpine AS build
+FROM node:18.20-alpine3.19 AS build
 
 ENV CHROME_BIN="/usr/bin/chromium-browser" \
     PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
@@ -12,7 +12,7 @@ COPY . /app/
 RUN yarn \
     && yarn pack
 
-FROM node:alpine AS mermaid-cli-current
+FROM node:18.20-alpine3.19 AS mermaid-cli-current
 
 WORKDIR /app
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

Chromium 128.0.6613.84-r0 (used in Alpine 3.20) seems to be having issues with puppeteer/mermaid-cli, so we can't use it yet.

Resolves failing CI in recent PRs (see https://github.com/mermaid-js/mermaid-cli/actions/workflows/compile-mermaid.yml), e.g.:

```console
$ bash run-tests.sh test-positive mermaid-js/mermaid-cli/mermaid-cli:10.9.2-PullRequest0733.12
Generating single mermaid chart

ProtocolError: Page.enable timed out. Increase the 'protocolTimeout' setting in launch/connect calls for a higher timeout if needed.
    at new Callback (file:///home/mermaidcli/node_modules/puppeteer-core/lib/esm/puppeteer/common/Connection.js:58:35)
    at CallbackRegistry.create (file:///home/mermaidcli/node_modules/puppeteer-core/lib/esm/puppeteer/common/Connection.js:103:26)
    at Connection._rawSend (file:///home/mermaidcli/node_modules/puppeteer-core/lib/esm/puppeteer/common/Connection.js:212:26)
    at CDPSessionImpl.send (file:///home/mermaidcli/node_modules/puppeteer-core/lib/esm/puppeteer/common/Connection.js:419:78)
    at FrameManager.initialize (file:///home/mermaidcli/node_modules/puppeteer-core/lib/esm/puppeteer/common/FrameManager.js:133:24)
    at CDPPage._CDPPage_initialize (file:///home/mermaidcli/node_modules/puppeteer-core/lib/esm/puppeteer/common/Page.js:834:70)
    at CDPPage._create (file:///home/mermaidcli/node_modules/puppeteer-core/lib/esm/puppeteer/common/Page.js:57:90)
    at file:///home/mermaidcli/node_modules/puppeteer-core/lib/esm/puppeteer/common/Target.js:125:32
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Target.page (file:///home/mermaidcli/node_modules/puppeteer-core/lib/esm/puppeteer/common/Target.js:128:23)
```

## :straight_ruler: Design Decisions

I've picked Node.JS v18.20, since it's a recent version of Node.JS v18.

We can use @dependabot to automatically update this later.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
