### PR TITLE
build: use `node:18.20-alpine3.19 in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:18.20-alpine3.19
 
 ENV CHROME_BIN="/usr/bin/chromium-browser" \
     PUPPETEER_SKIP_DOWNLOAD="true" 


### PR DESCRIPTION
## :bookmark_tabs: Summary

Chromium 128.0.6613.84-r0 (used in Alpine 3.20) seems to be having issues with puppeteer/mermaid-cli (especially in GitHub Actions), so we can't use it yet.

See: 294af9f99ee91243209ba14a6b05b46fca1515c0

Resolves https://github.com/mermaid-js/mermaid-cli/issues/762

## :straight_ruler: Design Decisions

N/A

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
  - I believe we already have E2E tests that cover this, e.g. https://github.com/mermaid-js/mermaid-cli/actions/runs/11211689722/job/31161097388 and https://github.com/mermaid-js/mermaid-cli/blob/082fd7fbfcef41a8d968a895ea45b68dde75110a/.github/workflows/release-publish.yml#L93-L96
- [x] :bookmark: targeted `master` branch
