### PR TITLE
fix: return SVGs as UInt8Array instead of `Buffer`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -313,7 +313,7 @@ async function renderMermaid (browser, definition, outputFormat, { viewport, bac
       })
       return {
         ...metadata,
-        data: Buffer.from(svgXML, 'utf8')
+        data: new TextEncoder().encode(svgXML)
       }
     } else if (outputFormat === 'png') {
       const clip = await page.$eval('svg', svg => {


### PR DESCRIPTION
## :bookmark_tabs: Summary

Currently, SVGs are returned as `Buffer`s from `renderMermaid()`, which is almost compatible with `UInt8Array`, but not 100%, which was causing TypeScript 5.6 to throw an error.

See: https://github.com/mermaid-js/mermaid-cli/pull/746

This should resolve the CI failure in https://github.com/mermaid-js/mermaid-cli/pull/746

## :straight_ruler: Design Decisions

N/A

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
  - Will be added by #746
- [x] :bookmark: targeted `master` branch
