### PR TITLE
fix: broaden `renderMermaid` browser type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -225,7 +225,7 @@ async function cli () {
 /**
  * Render a mermaid diagram.
  *
- * @param {import("puppeteer").Browser} browser - Puppeteer Browser
+ * @param {import("puppeteer").Browser | import("puppeteer").BrowserContext} browser - Puppeteer Browser
  * @param {string} definition - Mermaid diagram definition
  * @param {"svg" | "png" | "pdf"} outputFormat - Mermaid output format.
  * @param {ParseMDDOptions} [opt] - Options, see {@link ParseMDDOptions} for details.


### PR DESCRIPTION
## :bookmark_tabs: Summary

Allow passing either a Puppeteer Browser or a Puppeteer BrowserContext to `renderMermaid`, as both work fine.

See: https://pptr.dev/api/puppeteer.browser
See: https://pptr.dev/api/puppeteer.browsercontext

## :straight_ruler: Design Decisions

N/A

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
