### PR TITLE
build: skip bundling fonts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,6 @@
         "standard": "^17.0.0",
         "typescript": "^5.0.1-rc",
         "vite": "^4.0.3",
-        "vite-plugin-singlefile": "^0.13.1",
-        "vite-svg-loader": "^5.1.0",
         "yarn-upgrade-all": "^0.7.0"
       },
       "engines": {
@@ -2201,16 +2199,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@trysound/sax": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/@tsconfig/node18": {
       "version": "18.2.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.4.tgz",
@@ -3143,13 +3131,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -3676,50 +3657,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css-select": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-tree": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.0.30",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/css-what": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3732,42 +3669,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/csso": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
-      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-tree": "~2.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/csso/node_modules/css-tree": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
-      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.0.28",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/csso/node_modules/mdn-data": {
-      "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
-      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
-      "dev": true,
-      "license": "CC0-1.0"
     },
     "node_modules/csstype": {
       "version": "3.1.2",
@@ -4527,21 +4428,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
     "node_modules/dom-to-image-more": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/dom-to-image-more/-/dom-to-image-more-2.16.0.tgz",
@@ -4549,55 +4435,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
     "node_modules/dompurify": {
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
       "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ==",
       "license": "(MPL-2.0 OR Apache-2.0)"
-    },
-    "node_modules/domutils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.129",
@@ -4641,19 +4483,6 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -8135,13 +7964,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/mdn-data": {
-      "version": "2.0.30",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -8352,19 +8174,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/nth-check": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/object-assign": {
@@ -10291,41 +10100,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/svgo": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.2.tgz",
-      "integrity": "sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@trysound/sax": "0.2.0",
-        "commander": "^7.2.0",
-        "css-select": "^5.1.0",
-        "css-tree": "^2.2.1",
-        "csso": "^5.0.5",
-        "picocolors": "^1.0.0"
-      },
-      "bin": {
-        "svgo": "bin/svgo"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/svgo"
-      }
-    },
-    "node_modules/svgo/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/tailwindcss": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.2.tgz",
@@ -10852,36 +10626,6 @@
         "terser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite-plugin-singlefile": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/vite-plugin-singlefile/-/vite-plugin-singlefile-0.13.5.tgz",
-      "integrity": "sha512-y/aRGh8qHmw2f1IhaI/C6PJAaov47ESYDvUv1am1YHMhpY+19B5k5Odp8P+tgs+zhfvak6QB1ykrALQErEAo7g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "micromatch": "^4.0.5"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "rollup": ">=2.79.0",
-        "vite": ">=3.2.0"
-      }
-    },
-    "node_modules/vite-svg-loader": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vite-svg-loader/-/vite-svg-loader-5.1.0.tgz",
-      "integrity": "sha512-M/wqwtOEjgb956/+m5ZrYT/Iq6Hax0OakWbokj8+9PXOnB7b/4AxESHieEtnNEy7ZpjsjYW1/5nK8fATQMmRxw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "svgo": "^3.0.2"
-      },
-      "peerDependencies": {
-        "vue": ">=3.2.13"
       }
     },
     "node_modules/vscode-jsonrpc": {

--- a/package.json
+++ b/package.json
@@ -47,8 +47,6 @@
     "standard": "^17.0.0",
     "typescript": "^5.0.1-rc",
     "vite": "^4.0.3",
-    "vite-plugin-singlefile": "^0.13.1",
-    "vite-svg-loader": "^5.1.0",
     "yarn-upgrade-all": "^0.7.0"
   },
   "files": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,28 @@
 import { defineConfig } from "vite"
-import { viteSingleFile } from "vite-plugin-singlefile"
-import svgLoader from 'vite-svg-loader'
 
 export default defineConfig({
+  base: './',
   plugins: [
-    // bundle everything into a single `index.html`
-    viteSingleFile(),
-    // unsure if this is working properly for fontawesome fonts
-    svgLoader(),
-  ],
-})
+    {
+      name: 'IIFE-converter',
+      config(currentConfig, _unused) {
+        return {
+          ...currentConfig,
+          build: {
+            ...currentConfig.build,
+            rollupOptions: {
+              ...currentConfig.build?.rollupOptions,
+              output: {
+                ...currentConfig.build?.rollupOptions?.output,
+                format: 'iife',
+              }
+            }
+          }
+        };
+      },
+      transformIndexHtml(html) {
+        return html.replace('<script type="module" crossorigin', '<script charset="utf-8"')
+      }
+    }
+  ]
+});


### PR DESCRIPTION
## :bookmark_tabs: Summary

Compile JavaScript code as an IIFE, allowing us to avoid needing to inline anything.

This makes the code about 10% faster for me (tests run in 105s instead of 120s), and the size on the bundle went from 4MiB to 3.5MiB.

Additionally, **I've finally figured out the issue that was sometimes causing the FontAwesome icons to load incorrectly**: sometimes Puppeteer was parsing the CSS FontAwesome as Latin-1 instead of UTF-8! Explicitly setting the script to have `charset="utf-8"` seems to fix this!

Resolves https://github.com/mermaid-js/mermaid-cli/pull/699. Resolves https://github.com/mermaid-js/mermaid-cli/pull/700

## :straight_ruler: Design Decisions

Instead of bundling everything into a single giant `index.html` file, it's more efficient to have separate files, as otherwise, some files (e.g. the `.woff2` font files), need to be base64 encoding in the `.html`.

However, since `file://` is only supported for IIFE JavaScript files (not ESM), I've written a tiny custom `IIFE-converter` plugin for Vite that creates IIFE files instead.

### FontAwesome issues fixed

These Percy errors should now be fixed:

![image](https://github.com/user-attachments/assets/92fe3d1f-957d-46ab-8a53-90a3dcaaf880)

It turns out that FontAwesome v6's car icon is the following character: `` (e.g. the UTF-8 bytes are 0xef86b9). However, when Puppeteer was parsing the CSS, it was sometimes parsing it as Latin-1 instead of UTF-8, which instead resulted in the following characters: `ï†¹` (the Latin-1 bytes are still 0xef3fb9!). And since the font-file didn't have an entry for these three characters, it didn't display anything.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
