### PR TITLE
fix(types): correct `rootDir` in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     // next to the .js files
     // We can't use `dist/` as Vite will automatically overwrite it.
     "outDir": "dist-types",
+    "rootDir": ".",
     // go to js file when using IDE functions like
     // "Go to Definition" in VSCode
     "declarationMap": true,


### PR DESCRIPTION
## :bookmark_tabs: Summary

It looks like the default `rootDir` was `"."`, but for some reason, adding the `src/version.js` file changed the `rootDir` to `"./src/"`.

I'm not sure why this is, looking at the TypeScript `tsconfig` reference docs for `rootDir`: <https://www.typescriptlang.org/tsconfig/#rootDir>, they say:

> **Default**: The longest common path of all non-declaration input files.

Which should have already been `./src/`?

Regardless, I've explicitly set `rootDir: "."` to generate the types at `dist-types/src/index.d.ts` instead of the `dist-types/index.d.ts` it's being exported to since 9a42e3c408be34df19c58735eea444d3b0ac37c9.

Fixes: 9a42e3c408be34df19c58735eea444d3b0ac37c9
Fixes: https://github.com/mermaid-js/mermaid-cli/issues/803

## :straight_ruler: Design Decisions

N/A

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
