### PR TITLE
ci: use `aa-exec` to fix Puppeteer on Ubuntu 24.04 CI

### DIFF
--- a/.github/workflows/compile-mermaid.yml
+++ b/.github/workflows/compile-mermaid.yml
@@ -64,7 +64,8 @@ jobs:
           )
           # This will overwrite any PNG files with the same name that have been created by run-tests.sh
           # v0.5.0 is the last version to correctly convert our SVG files to PNG
-          npx --yes convert-svg-to-png@0.5.0 "${svg_files_to_convert[@]}"
+          # We use aa-exec since `convert-svg-to-png` uses puppeteer, which AppArmor blocks in Ubuntu 24.04
+          aa-exec --profile=chrome npx --yes convert-svg-to-png@0.5.0 "${svg_files_to_convert[@]}"
 
       - name: Upload diagrams for manual inspection
         # also uploads for `upload-percy.yml` action

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,5 +21,7 @@ jobs:
           cache: 'npm'
       # throws an error if package-lock.json is out-of-date
       - run: npm ci
-      # runs jest unittests
-      - run: npm test
+      # We use aa-exec since Ubuntu 24.04's AppArmor profile blocks the use
+      # of puppeteer otherwise, see
+      # https://github.com/puppeteer/puppeteer/issues/12818
+      - run: aa-exec --profile=chrome npm test


### PR DESCRIPTION
## :bookmark_tabs: Summary

Ubuntu 24.04 has stricter AppArmor policies that prevent Puppeteer from running, with an error like:

> Failed to launch the browser process!
> [0109/235031.343250:FATAL:zygote_host_impl_linux.cc(128)] No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor, see https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md. Otherwise see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the (older) SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.

We can use [`aa-exec`][1] to explicitly set the `chrome` policy and get it working again.

[1]: https://manpages.ubuntu.com/manpages/noble/man1/aa-exec.1.html

See: https://github.com/mermaid-js/mermaid-cli/issues/730#issuecomment-2408615110
See: https://github.com/actions/runner-images/issues/10015
See: https://github.com/puppeteer/puppeteer/issues/12818

## :straight_ruler: Design Decisions

I've used `aa-exec` since it's seems the easiest way to set the config, and it still means that Puppeteer uses most of it's sandbox features.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
  - Fixes existing E2E tests.
- [x] :bookmark: targeted `master` branch
