### PR TITLE
ci: fix skipping **Upload to Percy** on errors

### DIFF
--- a/.github/workflows/upload-percy.yml
+++ b/.github/workflows/upload-percy.yml
@@ -19,9 +19,9 @@ on:
 
 jobs:
   upload:
-    if: >
-      ${{ github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     permissions:
       # disable unused permissions
       actions: read


### PR DESCRIPTION
## :bookmark_tabs: Summary

Right now, when a test fails, the **Upload to Percy** CI job still runs, and fails.

I think this is because our syntax for the `if:` statement was wrong and had an extra newline/spaces, that was making GitHub Actions treat the statement as always `true`.

According to https://github.com/orgs/community/discussions/25641#discussioncomment-10617902, apparently `>-` and removing the outer `${{` and `}}` might help.

## :straight_ruler: Design Decisions

N/A

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
