### PR TITLE
Add Iconify support

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -40,6 +40,13 @@ for format in "svg" "png"; do
     -o "$outputFileName"
 done
 
+# Test if passing custom Iconify icons work
+outputFileName="/data/$INPUT_DATA/architecture-diagram-logos-with-icons.png"
+docker run --rm -v $(pwd):/data $IMAGETAG \
+  -i /data/$INPUT_DATA/architecture-diagram-logos.mmd \
+  --iconPacks '@iconify-json/logos' \
+  -o "$outputFileName"
+
 # Test if a diagram from STDIN can be understood
 cat $INPUT_DATA/flowchart1.mmd | docker run --rm -i -v $(pwd):/data $IMAGETAG -o /data/$INPUT_DATA/flowchart1-stdin.png -w 800
 

--- a/src-test/test.js
+++ b/src-test/test.js
@@ -469,7 +469,7 @@ describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {
 
     test('should show Iconify icon packs', async () => {
       const mmdInput = 'architecture-beta\n    group aws(logos:aws)[AWS]'
-      const result = await renderMermaid(browser, mmdInput, 'svg')
+      const result = await renderMermaid(browser, mmdInput, 'svg', { iconPacks: ['@iconify-json/logos'] })
       expectBytesAreFormat(result.data, 'svg')
       const decoder = new TextDecoder()
       expect(decoder.decode(result.data)).toContain('<path')

--- a/src-test/test.js
+++ b/src-test/test.js
@@ -466,5 +466,13 @@ describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {
       expect(result).toMatchObject({ title: 'Hi', desc: 'World' })
       expectBytesAreFormat(result.data, 'svg')
     })
+
+    test('should show Iconify icon packs', async () => {
+      const mmdInput = 'architecture-beta\n    group aws(logos:aws)[AWS]'
+      const result = await renderMermaid(browser, mmdInput, 'svg')
+      expectBytesAreFormat(result.data, 'svg')
+      const decoder = new TextDecoder();
+      expect(decoder.decode(result.data)).toContain('<path')
+    })
   })
 })

--- a/src-test/test.js
+++ b/src-test/test.js
@@ -471,7 +471,7 @@ describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {
       const mmdInput = 'architecture-beta\n    group aws(logos:aws)[AWS]'
       const result = await renderMermaid(browser, mmdInput, 'svg')
       expectBytesAreFormat(result.data, 'svg')
-      const decoder = new TextDecoder();
+      const decoder = new TextDecoder()
       expect(decoder.decode(result.data)).toContain('<path')
     })
   })

--- a/src/index.js
+++ b/src/index.js
@@ -120,11 +120,12 @@ async function cli () {
     .option('-f, --pdfFit', 'Scale PDF to fit chart')
     .option('-q, --quiet', 'Suppress log output')
     .option('-p --puppeteerConfigFile [puppeteerConfigFile]', 'JSON configuration file for puppeteer.')
+    .option('--icon-pack <icons...>', 'Icon packs to use, e.g. @iconify-json/logos', [])
     .parse(process.argv)
 
   const options = commander.opts()
 
-  let { theme, width, height, input, output, outputFormat, backgroundColor, configFile, cssFile, svgId, puppeteerConfigFile, scale, pdfFit, quiet } = options
+  let { theme, width, height, input, output, outputFormat, backgroundColor, configFile, cssFile, svgId, puppeteerConfigFile, scale, pdfFit, quiet, iconPacks } = options
 
   // check input file
   if (!input) {
@@ -205,7 +206,7 @@ async function cli () {
       quiet,
       outputFormat,
       parseMMDOptions: {
-        mermaidConfig, backgroundColor, myCSS, pdfFit, viewport: { width, height, deviceScaleFactor: scale }, svgId
+        mermaidConfig, backgroundColor, myCSS, pdfFit, viewport: { width, height, deviceScaleFactor: scale }, svgId, iconPacks
       }
     }
   )

--- a/src/index.js
+++ b/src/index.js
@@ -120,7 +120,7 @@ async function cli () {
     .option('-f, --pdfFit', 'Scale PDF to fit chart')
     .option('-q, --quiet', 'Suppress log output')
     .option('-p --puppeteerConfigFile [puppeteerConfigFile]', 'JSON configuration file for puppeteer.')
-    .option('--icon-pack <icons...>', 'Icon packs to use, e.g. @iconify-json/logos', [])
+    .option('--iconPacks <icons...>', 'Icon packs to use, e.g. @iconify-json/logos. These should be Iconfiy NPM packages that expose a icons.json file, see https://iconify.design/docs/icons/json.html. These will be downloaded from https://unkpg.com when needed.', [])
     .parse(process.argv)
 
   const options = commander.opts()

--- a/src/index.js
+++ b/src/index.js
@@ -264,6 +264,17 @@ async function renderMermaid (browser, definition, outputFormat, { viewport, bac
 
       await mermaid.registerExternalDiagrams([zenuml])
       mermaid.registerLayoutLoaders(elkLayouts)
+      // lazy load icon packs
+      const iconPacks = ['logos', 'mdi']
+      mermaid.registerIconPacks(
+        iconPacks.map((icon) => ({
+          name: icon,
+          loader: () =>
+            fetch(`https://unpkg.com/@iconify-json/${icon}/icons.json`)
+              .then((res) => res.json())
+              .catch(() => error(`Failed to fetch icon: ${icon}`))
+        }))
+      )
       mermaid.initialize({ startOnLoad: false, ...mermaidConfig })
       // should throw an error if mmd diagram is invalid
       const { svg: svgText } = await mermaid.render(svgId || 'my-svg', definition, container)

--- a/test-positive/architecture-diagram-logos.mmd
+++ b/test-positive/architecture-diagram-logos.mmd
@@ -1,0 +1,11 @@
+architecture-beta
+    group api(logos:aws-lambda)[API]
+
+    service db(logos:aws-aurora)[Database] in api
+    service disk1(logos:aws-glacier)[Storage] in api
+    service disk2(logos:aws-s3)[Storage] in api
+    service server(logos:aws-ec2)[Server] in api
+
+    db:L -- R:server
+    disk1:T -- B:server
+    disk2:T -- B:db


### PR DESCRIPTION
## :bookmark_tabs: Summary

Support Iconify icon packs that are used in `architecture-beta`.

Resolves https://github.com/mermaid-js/mermaid-cli/issues/764, https://github.com/mermaid-js/mermaid-cli/issues/805

## :straight_ruler: Design Decisions

I have the same issue described in the #764 and #805. I think it makes sense to add the way similar as the comment https://github.com/mermaid-js/mermaid-cli/issues/764#issuecomment-2448695522 to the upstream because it doesn't have any side effect if it's lazy load.
Although it might be reasonable to support any icon packs with a command line option, it would be good to support commonly used `logos` and `mdi` first as [Markdown Preview Mermaid Support](https://marketplace.visualstudio.com/items?itemName=bierner.markdown-mermaid) supports them.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
