### PR TITLE
feat: add iconPacksNamesAndUrls option in order to be able to use icons outside unpkg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mermaid-js/mermaid-cli",
-  "version": "11.6.0",
+  "version": "11.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mermaid-js/mermaid-cli",
-      "version": "11.6.0",
+      "version": "11.9.0",
       "license": "MIT",
       "dependencies": {
         "@mermaid-js/mermaid-zenuml": "^0.2.0",

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -56,6 +56,14 @@ docker run --rm -v $(pwd):/data $IMAGETAG \
   --iconPacks '@iconify-json/logos' \
   -o "$outputFileName"
 
+# Test if passing custom Iconify icons (from unpkg and other sources) work
+outputFileName="/data/$INPUT_DATA/flowchart1.png"
+docker run --rm -v $(pwd):/data $IMAGETAG \
+  -i /data/$INPUT_DATA/flowchart1.mmd \
+  --iconPacks '@iconify-json/logos' \
+  --iconPacksNamesAndUrls "azure#https://raw.githubusercontent.com/NakayamaKento/AzureIcons/refs/heads/main/icons.json" \
+  -o "$outputFileName"
+
 # Test if a diagram from STDIN can be understood
 cat $INPUT_DATA/flowchart1.mmd | docker run --rm -i -v $(pwd):/data $IMAGETAG -o /data/$INPUT_DATA/flowchart1-stdin.png -w 800
 

--- a/src-test/test.js
+++ b/src-test/test.js
@@ -478,5 +478,13 @@ describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {
       const decoder = new TextDecoder()
       expect(decoder.decode(result.data)).toContain('<path')
     })
+
+    test('should show Iconify icon packs and named iconpacks', async () => {
+      const mmdInput = 'flowchart TD\n    aws@{ icon: "logos:aws" } \n    resource-groups@{ icon: "azure:resource-groups", label: "resource-groups" }'
+      const result = await renderMermaid(browser, mmdInput, 'svg', { iconPacks: ['@iconify-json/logos'], iconPacksNamesAndUrls: ['azure#https://raw.githubusercontent.com/NakayamaKento/AzureIcons/refs/heads/main/icons.json'] })
+      expectBytesAreFormat(result.data, 'svg')
+      const decoder = new TextDecoder()
+      expect(decoder.decode(result.data)).toContain('<path')
+    })
   })
 })

--- a/src/index.js.bak
+++ b/src/index.js.bak
@@ -122,12 +122,11 @@ async function cli () {
     .option('-q, --quiet', 'Suppress log output')
     .option('-p --puppeteerConfigFile [puppeteerConfigFile]', 'JSON configuration file for puppeteer.')
     .option('--iconPacks <icons...>', 'Icon packs to use, e.g. @iconify-json/logos. These should be Iconify NPM packages that expose a icons.json file, see https://iconify.design/docs/icons/json.html. These will be downloaded from https://unkpg.com when needed.', [])
-    .option('--iconPacksNamesAndUrls <prefix#iconsurl...>', 'Icon packs to use, e.g. azure#https://raw.githubusercontent.com/NakayamaKento/AzureIcons/refs/heads/main/icons.json where the name (prefix) of the icon pack is defined before the "#" and the url of the json definition after the "#". These should be Iconify json file formatted as IconifyJson, see https://iconify.design/docs/icons/json.html. These will be downloaded when needed.', [])
     .parse(process.argv)
 
   const options = commander.opts()
 
-  let { theme, width, height, input, output, outputFormat, backgroundColor, configFile, cssFile, svgId, puppeteerConfigFile, scale, pdfFit, quiet, iconPacks, iconPacksNamesAndUrls, artefacts } = options
+  let { theme, width, height, input, output, outputFormat, backgroundColor, configFile, cssFile, svgId, puppeteerConfigFile, scale, pdfFit, quiet, iconPacks, artefacts } = options
 
   // check input file
   if (!input) {
@@ -217,7 +216,7 @@ async function cli () {
       quiet,
       outputFormat,
       parseMMDOptions: {
-        mermaidConfig, backgroundColor, myCSS, pdfFit, viewport: { width, height, deviceScaleFactor: scale }, svgId, iconPacks, iconPacksNamesAndUrls
+        mermaidConfig, backgroundColor, myCSS, pdfFit, viewport: { width, height, deviceScaleFactor: scale }, svgId, iconPacks
       },
       artefacts
     }
@@ -233,7 +232,7 @@ async function cli () {
  * @property {boolean} [pdfFit] - If set, scale PDF to fit chart.
  * @property {string} [svgId] - The id attribute for the SVG element to be rendered.
  * @property {string[]} [iconPacks] - Icon packages to use.
- * @property {string[]} [iconPacksNamesAndUrls] - IconPack Json file name and url to use.
+ */
 
 /**
  * Render a mermaid diagram.
@@ -245,7 +244,7 @@ async function cli () {
  * @returns {Promise<{title: string | null, desc: string | null, data: Uint8Array}>} The output file in bytes,
  * with optional metadata.
  */
-async function renderMermaid (browser, definition, outputFormat, { viewport, backgroundColor = 'white', mermaidConfig = {}, myCSS, pdfFit, svgId, iconPacks = [], iconPacksNamesAndUrls = [] } = {}) {
+async function renderMermaid (browser, definition, outputFormat, { viewport, backgroundColor = 'white', mermaidConfig = {}, myCSS, pdfFit, svgId, iconPacks = [] } = {}) {
   const page = await browser.newPage()
   page.on('console', (msg) => {
     console.warn(msg.text())
@@ -263,7 +262,7 @@ async function renderMermaid (browser, definition, outputFormat, { viewport, bac
       page.addScriptTag({ path: mermaidIIFEPath }),
       page.addScriptTag({ path: zenumlIIFEPath })
     ])
-    const metadata = await page.$eval('#container', async (container, definition, mermaidConfig, myCSS, backgroundColor, svgId, iconPacks, iconPacksNamesAndUrls) => {
+    const metadata = await page.$eval('#container', async (container, definition, mermaidConfig, myCSS, backgroundColor, svgId, iconPacks) => {
       await Promise.all(Array.from(document.fonts, (font) => font.load()))
 
       /**
@@ -279,7 +278,6 @@ async function renderMermaid (browser, definition, outputFormat, { viewport, bac
       await mermaid.registerExternalDiagrams([zenuml])
       mermaid.registerLayoutLoaders(elkLayouts)
       // lazy load icon packs
-
       mermaid.registerIconPacks(
         iconPacks.map((icon) => ({
           name: icon.split('/')[1],
@@ -288,26 +286,6 @@ async function renderMermaid (browser, definition, outputFormat, { viewport, bac
               .then((res) => res.json())
               .catch(() => error(`Failed to fetch icon: ${icon}`))
         }))
-      )
-
-      mermaid.registerIconPacks(
-        iconPacksNamesAndUrls.map((iconPackInfo) => 
-          {
-            var packName = iconPackInfo.split('#')[0];
-            var packUrl = iconPackInfo.split('#')[1];
-
-            return ({
-              name: packName,
-              loader: () =>
-                fetch(packUrl)
-                  .then((res) => res.json())
-                  .catch(() => {
-                    error(`Failed to fetch icon: ${iconPackInfo}`);
-                  })
-              }
-            )
-          }
-        )
       )
       mermaid.initialize({ startOnLoad: false, ...mermaidConfig })
       // should throw an error if mmd diagram is invalid
@@ -347,7 +325,7 @@ async function renderMermaid (browser, definition, outputFormat, { viewport, bac
       return {
         title, desc
       }
-    }, definition, mermaidConfig, myCSS, backgroundColor, svgId, iconPacks, iconPacksNamesAndUrls)
+    }, definition, mermaidConfig, myCSS, backgroundColor, svgId, iconPacks)
 
     if (outputFormat === 'svg') {
       const svgXML = await page.$eval('svg', (svg) => {

--- a/test-positive/flowchart4.mmd
+++ b/test-positive/flowchart4.mmd
@@ -1,0 +1,12 @@
+flowchart LR
+
+	aca@{ label: "azure-container-app", icon: "azure:worker-container-app", pos: "b"}
+	apicon@{ label: "api-connection", icon: "azure:api-connections", pos: "b"}
+	sql@{ label: "sql-database", icon: "azure:sql-database", pos: "b"}
+	redis@{ label: "redis", icon: "azure:cache-redis", pos: "b"}
+	cosmosdb@{ label: "Database:catalog<br/>Container:article", icon: "azure:azure-cosmos-db", pos: "b"}
+
+	aca --> apicon
+	aca --> sql
+	aca --> redis
+	aca --> cosmosdb


### PR DESCRIPTION
## Description
`iconPacks` option allows only to target icons stored in unpkg
There are icons available outside of unpkg (as the ones used on mermaid chart  playground)

added `iconPacksNamesAndUrls` option that looks like `iconPacks` option but gives the opportunity to use any valid Iconify json file (example : azure**#**https://raw.githubusercontent.com/NakayamaKento/AzureIcons/refs/heads/main/icons.json)
