### PR TITLE
feat: support fractional scaling

### DIFF
--- a/src-test/test.js
+++ b/src-test/test.js
@@ -316,6 +316,22 @@ describe('mermaid-cli', () => {
       await fs.copyFile(`test-output/flowchart1-with-css.${format}`, 'docs/animated-flowchart.svg')
     }
   }, timeout)
+
+  test('should support fractional scale argument', async () => {
+    const [small, normal, large] = await Promise.all([0.5, 1, 1.5].map(async(scale) => {
+      const outputFileName = `test-output/flowchart1-with-scale-${scale}.png`;
+      await promisify(execFile)('node', [
+        'src/cli.js', '--input=test-positive/flowchart1.mmd', '--output', outputFileName,
+        '--scale', scale]);
+      const bytes = await fs.readFile(outputFileName);
+      expectBytesAreFormat(bytes, 'png');
+      // PNG width is a 4-byte unsigned big-endian integer at byte offset 16
+      return bytes.readUInt32BE(16);
+    }));
+
+    expect(small).toBeCloseTo(normal * 0.5, -1);
+    expect(large).toBeCloseTo(normal * 1.5, -1);
+  }, timeout);
 })
 
 describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {

--- a/src/index.js
+++ b/src/index.js
@@ -102,6 +102,22 @@ function parseCommanderInt (value, _unused) {
   return parsedValue
 }
 
+/**
+ * Commander parser that converts a string to a float.
+ *
+ * @param {string} value - The value from commander.
+ * @param {*} _unused - Unused.
+ * @returns {number} The value parsed as a number.
+ * @see https://github.com/tj/commander.js/wiki/Class:-Option#argparserfn
+ */
+function parseCommanderFloat (value, _unused) {
+  const parsedValue = parseFloat(value)
+  if (isNaN(parsedValue) || parsedValue <= 0) {
+    throw new InvalidArgumentError('Not a positive number.')
+  }
+  return parsedValue
+}
+
 async function cli () {
   const commander = new Command()
   commander
@@ -117,7 +133,7 @@ async function cli () {
     .option('-c, --configFile [configFile]', 'JSON configuration file for mermaid.')
     .option('-C, --cssFile [cssFile]', 'CSS file for the page.')
     .option('-I, --svgId [svgId]', 'The id attribute for the SVG element to be rendered.')
-    .addOption(new Option('-s, --scale [scale]', 'Puppeteer scale factor').argParser(parseCommanderInt).default(1))
+    .addOption(new Option('-s, --scale [scale]', 'Puppeteer scale factor').argParser(parseCommanderFloat).default(1))
     .option('-f, --pdfFit', 'Scale PDF to fit chart')
     .option('-q, --quiet', 'Suppress log output')
     .option('-p --puppeteerConfigFile [puppeteerConfigFile]', 'JSON configuration file for puppeteer.')


### PR DESCRIPTION
## :bookmark_tabs: Summary

The scale argument was parsed as an integer, but `deviceScaleFactor` supports floats

## :straight_ruler: Design Decisions

- Created the `parseCommanderFloat` function based on the existing `parseCommanderInt`
- Added e2e tests
- Fixed e2e test script so that it passes locally for me
- Commited the package-lock.json changes

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
