### PR TITLE
feat: Add single-file Windows executable using Deno

### DIFF
--- a/.github/workflows/build-single-file.yml
+++ b/.github/workflows/build-single-file.yml
@@ -1,0 +1,64 @@
+name: Build Single-File Executable
+
+on:
+  push:
+    branches: [master]
+    tags:
+      - "v*"
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build-windows-exe:
+    runs-on: windows-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Build Windows executable
+        shell: bash
+        run: |
+          deno compile \
+            --allow-all \
+            --node-modules-dir \
+            --target x86_64-pc-windows-msvc \
+            --output mmdc.exe \
+            npm:@mermaid-js/mermaid-cli
+
+      - name: Verify executable exists
+        shell: bash
+        run: ls -lh mmdc.exe
+
+      - name: Test the executable
+        shell: bash
+        run: |
+          # Create a simple test diagram
+          echo 'graph TD; A-->B; A-->C; B-->D; C-->D;' > test.mmd
+          ./mmdc.exe -i test.mmd -o test.png
+          ls -la test.png test.mmd
+
+      - name: Upload artifact (for testing)
+        uses: actions/upload-artifact@v4
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          name: mmdc-windows-exe
+          path: |
+            mmdc.exe
+            test.mmd
+            test.png
+
+      - name: Upload as release asset
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          files: mmdc.exe
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -211,6 +211,18 @@ it installs (`mmdc`).  `npx -p @mermaid-js/mermaid-cli mmdc -h`
 > brew install mermaid-cli
 > ```
 
+## Standalone Windows Executable
+
+A single-file Windows executable (`.exe`) is available for download from the [GitHub Releases](https://github.com/mermaid-js/mermaid-cli/releases). This allows using mermaid-cli on Windows without installing Node.js or npm.
+
+Simply download the `mmdc.exe` from the latest release and run:
+
+```cmd
+mmdc.exe -i input.mmd -o output.svg
+```
+
+The executable includes all dependencies (including Chromium for rendering).
+
 
 ## Known issues
 


### PR DESCRIPTION
## Summary

This PR adds a GitHub Actions workflow to build a single-file Windows executable (.exe) for mermaid-cli using Deno's compile feature.

## Problem

Issue #467 requests a single-file Windows executable so non-developers can use mermaid-cli without installing Node.js/npm. The original solution (pkg) was deprecated and never supported ESM modules.

## Solution

Use **Deno** to build the executable:
- Deno natively supports ESM (the module format used by mermaid-cli)
- `deno compile` packages all dependencies into a single executable
- Cross-compile from Windows GitHub Actions runner to `x86_64-pc-windows-msvc`

## Changes

1. **New workflow**: `.github/workflows/build-single-file.yml`
   - Runs on: push to master, new tags, and manual trigger
   - Uses `denoland/setup-deno` action
   - Builds with: `deno compile --target x86_64-pc-windows-msvc`
   - Uploads as release asset on tagged releases
   
2. **Documentation**: Updated README.md with standalone executable usage

## Testing

The workflow can be tested manually or by creating a tag:
- Manual: Use workflow_dispatch trigger
- Release: Create a new release to build and upload .exe

## Related Issues

Closes #467