### PR TITLE
perf: load mermaid code as ESM instead of IIFE

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,11 +10,6 @@
       import "@fortawesome/fontawesome-free/css/solid.css"
       import "@fortawesome/fontawesome-free/css/fontawesome.css"
       import "katex/dist/katex.css"
-
-      import elkLayouts from "@mermaid-js/layout-elk"
-
-      // expose elkLayouts to the global scope so that puppeteer can see it
-      globalThis.elkLayouts = elkLayouts
     </script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "11.12.0",
       "license": "MIT",
       "dependencies": {
+        "@mermaid-js/layout-elk": "^0.1.2",
         "@mermaid-js/mermaid-zenuml": "^0.2.0",
         "chalk": "^5.0.1",
         "commander": "^14.0.0",
@@ -20,7 +21,6 @@
       },
       "devDependencies": {
         "@fortawesome/fontawesome-free": "^7.0.1",
-        "@mermaid-js/layout-elk": "^0.1.2",
         "@tsconfig/node18": "^18.2.4",
         "@types/node": "~18.19.31",
         "jest": "^30.0.5",
@@ -2046,7 +2046,6 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/@mermaid-js/layout-elk/-/layout-elk-0.1.8.tgz",
       "integrity": "sha512-uU+Glm1tQZScphrFuzf6dzPpYTrET3sz6Q2SqpLj/nr+FpO6cfgJmYdJ+vWA8oGoeNQZLVey480qbKAFk8DBuQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "d3": "^7.9.0",
@@ -5342,7 +5341,6 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.3.tgz",
       "integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==",
-      "dev": true,
       "license": "EPL-2.0"
     },
     "node_modules/emittery": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lint-fix": "standard --fix"
   },
   "dependencies": {
+    "@mermaid-js/layout-elk": "^0.1.2",
     "@mermaid-js/mermaid-zenuml": "^0.2.0",
     "chalk": "^5.0.1",
     "commander": "^14.0.0",
@@ -40,7 +41,6 @@
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^7.0.1",
-    "@mermaid-js/layout-elk": "^0.1.2",
     "@tsconfig/node18": "^18.2.4",
     "@types/node": "~18.19.31",
     "jest": "^30.0.5",

--- a/src/index.js
+++ b/src/index.js
@@ -12,17 +12,12 @@ import { Interceptor } from './puppeteerIntercept.js'
 const __dirname = url.fileURLToPath(new url.URL('.', import.meta.url))
 
 /**
- * Mermaid.js IFFE path.
- *
- * Importing this in a browser adds a global `mermaid` object.
+ * ESM bundles. Our interceptor doesn't support loading ESM modules that load
+ * other modules using relative paths, so these have to no `dependencies`.
  */
-const mermaidIIFEPath = path.resolve(path.dirname(url.fileURLToPath(resolve('mermaid', import.meta.url))), 'mermaid.js')
-const zenumlIIFEPath = path.resolve(path.dirname(url.fileURLToPath(resolve('@mermaid-js/mermaid-zenuml', import.meta.url))), 'mermaid-zenuml.js')
-
-/**
- * ELK bundles. Make sure these don't import anything else.
- */
+const mermaidESMPath = path.resolve(path.dirname(url.fileURLToPath(resolve('mermaid', import.meta.url))), 'mermaid.esm.mjs')
 const elkESMPath = path.resolve(path.dirname(url.fileURLToPath(resolve('@mermaid-js/layout-elk', import.meta.url))), 'mermaid-layout-elk.esm.mjs')
+const zenumlESMPath = path.resolve(path.dirname(url.fileURLToPath(resolve('@mermaid-js/mermaid-zenuml', import.meta.url))), 'mermaid-zenuml.esm.mjs')
 
 /**
  * Prints an error to stderr, then closes with exit code 1
@@ -265,29 +260,20 @@ async function renderMermaid (browser, definition, outputFormat, { viewport, bac
     await page.$eval('body', (body, backgroundColor) => {
       body.style.background = backgroundColor
     }, backgroundColor)
-    await Promise.all([
-      page.addScriptTag({ path: mermaidIIFEPath }),
-      page.addScriptTag({ path: zenumlIIFEPath })
-    ])
 
     const interceptor = new Interceptor()
+    const mermaidUrl = await interceptor.fileUrlToInterceptUrl(url.pathToFileURL(mermaidESMPath))
     const elkUrl = await interceptor.fileUrlToInterceptUrl(url.pathToFileURL(elkESMPath))
+    const zenumlUrl = await interceptor.fileUrlToInterceptUrl(url.pathToFileURL(zenumlESMPath))
 
     page.on('request', interceptor.interceptRequestHandler)
     await page.setRequestInterception(true)
 
-    const metadata = await page.$eval('#container', async (container, { definition, mermaidConfig, myCSS, backgroundColor, svgId, iconPacks, iconPacksNamesAndUrls, elkUrl }) => {
+    const metadata = await page.$eval('#container', async (container, { definition, mermaidConfig, myCSS, backgroundColor, svgId, iconPacks, iconPacksNamesAndUrls, elkUrl, mermaidUrl, zenumlUrl }) => {
+      const { default: mermaid } = await import(mermaidUrl)
       const { default: elkLayouts } = await import(elkUrl)
+      const { default: zenuml } = await import(zenumlUrl)
       await Promise.all(Array.from(document.fonts, (font) => font.load()))
-
-      /**
-       * @typedef {Object} GlobalThisWithMermaid
-       * We've already imported these modules in our `index.html` file (or by running `page.addScriptTag`),
-       * so that they get correctly bundled.
-       * @property {import("mermaid")["default"]} mermaid Already imported mermaid instance
-       * @property {import("@mermaid-js/mermaid-zenuml")["default"]} mermaid-zenuml Already imported mermaid-zenuml instance
-       */
-      const { mermaid, 'mermaid-zenuml': zenuml } = /** @type {GlobalThisWithMermaid & typeof globalThis} */ (globalThis)
 
       await mermaid.registerExternalDiagrams([zenuml])
       mermaid.registerLayoutLoaders(elkLayouts)
@@ -359,7 +345,7 @@ async function renderMermaid (browser, definition, outputFormat, { viewport, bac
       return {
         title, desc
       }
-    }, { definition, mermaidConfig, myCSS, backgroundColor, svgId, iconPacks, iconPacksNamesAndUrls, elkUrl })
+    }, { definition, mermaidConfig, myCSS, backgroundColor, svgId, iconPacks, iconPacksNamesAndUrls, elkUrl, mermaidUrl, zenumlUrl })
 
     if (outputFormat === 'svg') {
       const svgXML = await page.$eval('svg', (svg) => {

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import path from 'path'
 import puppeteer from 'puppeteer'
 import url from 'url'
 import { version } from './version.js'
+import { Interceptor } from './puppeteerIntercept.js'
 
 // __dirname is not available in ESM modules by default
 const __dirname = url.fileURLToPath(new url.URL('.', import.meta.url))
@@ -17,6 +18,11 @@ const __dirname = url.fileURLToPath(new url.URL('.', import.meta.url))
  */
 const mermaidIIFEPath = path.resolve(path.dirname(url.fileURLToPath(resolve('mermaid', import.meta.url))), 'mermaid.js')
 const zenumlIIFEPath = path.resolve(path.dirname(url.fileURLToPath(resolve('@mermaid-js/mermaid-zenuml', import.meta.url))), 'mermaid-zenuml.js')
+
+/**
+ * ELK bundles. Make sure these don't import anything else.
+ */
+const elkESMPath = path.resolve(path.dirname(url.fileURLToPath(resolve('@mermaid-js/layout-elk', import.meta.url))), 'mermaid-layout-elk.esm.mjs')
 
 /**
  * Prints an error to stderr, then closes with exit code 1
@@ -263,7 +269,15 @@ async function renderMermaid (browser, definition, outputFormat, { viewport, bac
       page.addScriptTag({ path: mermaidIIFEPath }),
       page.addScriptTag({ path: zenumlIIFEPath })
     ])
-    const metadata = await page.$eval('#container', async (container, { definition, mermaidConfig, myCSS, backgroundColor, svgId, iconPacks, iconPacksNamesAndUrls }) => {
+
+    const interceptor = new Interceptor()
+    const elkUrl = await interceptor.fileUrlToInterceptUrl(url.pathToFileURL(elkESMPath))
+
+    page.on('request', interceptor.interceptRequestHandler)
+    await page.setRequestInterception(true)
+
+    const metadata = await page.$eval('#container', async (container, { definition, mermaidConfig, myCSS, backgroundColor, svgId, iconPacks, iconPacksNamesAndUrls, elkUrl }) => {
+      const { default: elkLayouts } = await import(elkUrl)
       await Promise.all(Array.from(document.fonts, (font) => font.load()))
 
       /**
@@ -272,9 +286,8 @@ async function renderMermaid (browser, definition, outputFormat, { viewport, bac
        * so that they get correctly bundled.
        * @property {import("mermaid")["default"]} mermaid Already imported mermaid instance
        * @property {import("@mermaid-js/mermaid-zenuml")["default"]} mermaid-zenuml Already imported mermaid-zenuml instance
-       * @property {import("@mermaid-js/layout-elk")["default"]} elkLayouts Already imported mermaid-elkLayouts instance
        */
-      const { mermaid, 'mermaid-zenuml': zenuml, elkLayouts } = /** @type {GlobalThisWithMermaid & typeof globalThis} */ (globalThis)
+      const { mermaid, 'mermaid-zenuml': zenuml } = /** @type {GlobalThisWithMermaid & typeof globalThis} */ (globalThis)
 
       await mermaid.registerExternalDiagrams([zenuml])
       mermaid.registerLayoutLoaders(elkLayouts)
@@ -346,7 +359,7 @@ async function renderMermaid (browser, definition, outputFormat, { viewport, bac
       return {
         title, desc
       }
-    }, { definition, mermaidConfig, myCSS, backgroundColor, svgId, iconPacks, iconPacksNamesAndUrls })
+    }, { definition, mermaidConfig, myCSS, backgroundColor, svgId, iconPacks, iconPacksNamesAndUrls, elkUrl })
 
     if (outputFormat === 'svg') {
       const svgXML = await page.$eval('svg', (svg) => {

--- a/src/index.js
+++ b/src/index.js
@@ -291,22 +291,21 @@ async function renderMermaid (browser, definition, outputFormat, { viewport, bac
       )
 
       mermaid.registerIconPacks(
-        iconPacksNamesAndUrls.map((iconPackInfo) => 
-          {
-            var packName = iconPackInfo.split('#')[0];
-            var packUrl = iconPackInfo.split('#')[1];
+        iconPacksNamesAndUrls.map((iconPackInfo) => {
+          const packName = iconPackInfo.split('#')[0]
+          const packUrl = iconPackInfo.split('#')[1]
 
-            return ({
-              name: packName,
-              loader: () =>
-                fetch(packUrl)
-                  .then((res) => res.json())
-                  .catch(() => {
-                    error(`Failed to fetch icon: ${iconPackInfo}`);
-                  })
-              }
-            )
+          return ({
+            name: packName,
+            loader: () =>
+              fetch(packUrl)
+                .then((res) => res.json())
+                .catch(() => {
+                  error(`Failed to fetch icon: ${iconPackInfo}`)
+                })
           }
+          )
+        }
         )
       )
       mermaid.initialize({ startOnLoad: false, ...mermaidConfig })

--- a/src/index.js
+++ b/src/index.js
@@ -263,7 +263,7 @@ async function renderMermaid (browser, definition, outputFormat, { viewport, bac
       page.addScriptTag({ path: mermaidIIFEPath }),
       page.addScriptTag({ path: zenumlIIFEPath })
     ])
-    const metadata = await page.$eval('#container', async (container, definition, mermaidConfig, myCSS, backgroundColor, svgId, iconPacks, iconPacksNamesAndUrls) => {
+    const metadata = await page.$eval('#container', async (container, { definition, mermaidConfig, myCSS, backgroundColor, svgId, iconPacks, iconPacksNamesAndUrls }) => {
       await Promise.all(Array.from(document.fonts, (font) => font.load()))
 
       /**
@@ -346,7 +346,7 @@ async function renderMermaid (browser, definition, outputFormat, { viewport, bac
       return {
         title, desc
       }
-    }, definition, mermaidConfig, myCSS, backgroundColor, svgId, iconPacks, iconPacksNamesAndUrls)
+    }, { definition, mermaidConfig, myCSS, backgroundColor, svgId, iconPacks, iconPacksNamesAndUrls })
 
     if (outputFormat === 'svg') {
       const svgXML = await page.$eval('svg', (svg) => {

--- a/src/puppeteerIntercept.js
+++ b/src/puppeteerIntercept.js
@@ -1,0 +1,91 @@
+/**
+ * @import puppeteer from 'puppeteer';
+ */
+
+import { readFile, realpath } from 'node:fs/promises'
+import path from 'node:path'
+import url from 'node:url'
+
+/**
+ * Puppeteer doesn't allow importing ESM modules from `file://` URLs.
+ * We don't want to create a dummy http server to serve ESM modules
+ * (since that would cause issues with ports/firewalls), so this module
+ * instead intercepts dummy `https://mermaid-cli-intercept.invalid` requests.
+ */
+export class Interceptor {
+  #INTERCEPT_ORIGIN = 'https://mermaid-cli-intercept.invalid'
+
+  /**
+     * Set of allowed file directories that can be intercepted.
+     *
+     * This is used to prevent arbitrary file access through the intercept mechanism.
+     *
+     * Make sure to use `realpath` to resolve any symlinks.
+     *
+     * @type {Set<string>}
+     */
+  #allowedDirs = new Set()
+
+  /**
+     * @param {URL | `file://${string}`} fileUrl - File URL
+     */
+  async fileUrlToInterceptUrl (fileUrl) {
+    fileUrl = new URL(fileUrl)
+    if (fileUrl.protocol !== 'file:') {
+      throw new Error(`Invalid file URL: ${fileUrl}`)
+    }
+    this.#allowedDirs.add(path.dirname(await realpath(url.fileURLToPath(fileUrl))))
+    return `${this.#INTERCEPT_ORIGIN}${fileUrl.pathname}`
+  }
+
+  /**
+     *
+     * @param {URL | string} interceptUrl
+     * @throws {Error} If the URL is not a valid intercept URL
+     */
+  async interceptUrlToFileUrl (interceptUrl) {
+    interceptUrl = new URL(interceptUrl)
+    if (interceptUrl.origin !== this.#INTERCEPT_ORIGIN) {
+      throw new Error(`Invalid intercept URL: ${interceptUrl}`)
+    }
+    const fileUrl = new URL(interceptUrl.href.slice(this.#INTERCEPT_ORIGIN.length), 'file://')
+    const filePath = await realpath(url.fileURLToPath(fileUrl))
+    if (![...this.#allowedDirs].some(dir => path.relative(filePath, dir).startsWith('..'))) {
+      throw new Error(`Intercept URL is not in an allowed directory: ${interceptUrl}`)
+    }
+    return fileUrl
+  }
+
+  /**
+     * @param {puppeteer.HTTPRequest} request - The intercepted request
+     */
+  async #interceptRequestHandler (request) {
+    try {
+      if (request.url().startsWith(this.#INTERCEPT_ORIGIN)) {
+        const fileUrl = await this.interceptUrlToFileUrl(request.url())
+        return request.respond({
+          status: 200,
+          headers: {
+            'Access-Control-Allow-Origin': '*'
+          },
+          contentType: 'application/javascript',
+          body: await readFile(fileUrl)
+        })
+      }
+    } catch (error) {
+      console.error(`Error handling intercept request for ${request.url()}:`, error)
+      request.abort()
+    }
+    request.continue()
+  }
+
+  /**
+     * Intercepts requests to `https://mermaid-cli-intercept.invalid`
+     * and serves the corresponding file content.
+     *
+     * @return {puppeteer.Handler<puppeteer.HTTPRequest>}
+     */
+  get interceptRequestHandler () {
+    return this.#interceptRequestHandler.bind(this)
+  }
+}

--- a/test-positive/flowchart-elk.mmd
+++ b/test-positive/flowchart-elk.mmd
@@ -1,0 +1,11 @@
+---
+title: Flowchart with ELK layout
+config:
+    layout: elk
+---
+flowchart TD
+    A[Christmas] -->|Get money| B(Go shopping)
+    B --> C{Let me think}
+    C -.->|One| D[Laptop]
+    C -.->|Two| E[iPhone]
+    C -.->|Three| F[Car]


### PR DESCRIPTION
## :bookmark_tabs: Summary

Currently, we've been bundling the `@mermaid-js/layout-elk` dependency, since it is ESM-only, and Puppeteer cannot load ESM code from `file://` URIs.

We're also loading `@mermaid-js/mermaid-zenuml` and `mermaid` as IIFE bundles for the same reason.

This commit adds a `page.on('request', () =>` interceptor that treats requests to `https://mermaid-cli-intercept.invalid`/ as requests to the given file. For security reasons, only explicitly allowed folders can be read this way.

For `mermaid-cli`, running the tests for me now only takes 72s, instead of the 136s previously, so it's about 1.9x times faster!

## :straight_ruler: Design Decisions

N/A

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
