### PR TITLE
Revert "build(deps): bump commander from 13.1.0 to 14.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@mermaid-js/layout-elk": "^0.1.2",
         "@mermaid-js/mermaid-zenuml": "^0.2.0",
         "chalk": "^5.0.1",
-        "commander": "^14.0.0",
+        "commander": "^13.1.0",
         "import-meta-resolve": "^4.1.0",
         "mermaid": "^11.14.0"
       },
@@ -4494,12 +4494,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
-      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/concat-map": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@mermaid-js/layout-elk": "^0.1.2",
     "@mermaid-js/mermaid-zenuml": "^0.2.0",
     "chalk": "^5.0.1",
-    "commander": "^14.0.0",
+    "commander": "^13.1.0",
     "import-meta-resolve": "^4.1.0",
     "mermaid": "^11.14.0"
   },


### PR DESCRIPTION
## :bookmark_tabs: Summary

This reverts commit c853cc05990c4de5d2c86a1c05a8bf60b9703c2d.

Commander v14 officially drops Node.JS v18, which we still support.

## :straight_ruler: Design Decisions

N/A

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
