### PR TITLE
fix: bump `@mermaid-js/layout-elk` to `^0.1.5 || ^0.2`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,21 +6,45 @@ permissions:
 
 jobs:
   test:
-    name: Test
+    name: Test Node.js ${{ matrix.node }} with ${{ matrix.dependencies }} dependencies
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       matrix:
         node: [ 18.19 ]
+        dependencies:
+          # default `package-lock.json` dependencies
+          - 'default'
+          # install with oldest dependencies without optional dependencies
+          - 'minimal'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.JS ${{ matrix.node }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node }}
-          cache: 'npm'
+          package-manager-cache: false
+
+      - name: Get NPM cache directory
+        id: npm-cache
+        run: echo "cache-dir=$(npm config get cache)" >> $GITHUB_OUTPUT
+
+      - name: Cache node modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          # Use a different cache key for `-minimal` dependencies, since they won't match the `package-lock.json` hash
+          # Cache key format is adapted from https://github.com/actions/setup-node/blob/670825a89dc0abd596e7a3abd0f5e3f6e5faf37c/src/cache-restore.ts#L43-L44
+          key: node-cache-${{ runner.os }}-${{ runner.arch }}-npm-${{ hashFiles('**/package-lock.json') }}${{ case(matrix.dependencies == 'default', '', '-${{ matrix.dependencies }}') }}
+          restore-keys: node-cache-${{ runner.os }}-${{ runner.arch }}-npm-${{ hashFiles('**/package-lock.json') }}
+          path: ${{ steps.npm-cache.outputs.cache-dir }}
+          
       # throws an error if package-lock.json is out-of-date
       - run: npm ci
+
+      - name: Install minimal dependencies
+        run: node ./scripts/install-minimum.js
+        if: matrix.dependencies == 'minimal'
+
       # We use aa-exec since Ubuntu 24.04's AppArmor profile blocks the use
       # of puppeteer otherwise, see
       # https://github.com/puppeteer/puppeteer/issues/12818

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "11.12.0",
       "license": "MIT",
       "dependencies": {
-        "@mermaid-js/layout-elk": "^0.1.2 || ^0.2.0",
+        "@mermaid-js/layout-elk": "^0.1.5 || ^0.2.0",
         "@mermaid-js/mermaid-zenuml": "^0.2.0",
         "chalk": "^5.0.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint-fix": "standard --fix"
   },
   "dependencies": {
-    "@mermaid-js/layout-elk": "^0.1.2 || ^0.2.0",
+    "@mermaid-js/layout-elk": "^0.1.5 || ^0.2.0",
     "@mermaid-js/mermaid-zenuml": "^0.2.0",
     "chalk": "^5.0.1",
     "commander": "^13.1.0",

--- a/scripts/install-minimum.js
+++ b/scripts/install-minimum.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from 'node:fs/promises'
+import { execFileSync } from 'child_process'
+import semver from 'semver'
+
+/**
+ * Installs the minimum dependencies of this package for testing.
+ *
+ * @TODO We might be able to switch to using PNPM's `resolutionMode=lowest-direct`
+ *       for this later.
+ */
+async function main () {
+  const packageJson = JSON.parse(await readFile('package.json', 'utf8'))
+
+  for (const dependencyType of ['dependencies', 'peerDependencies']) {
+    for (const [packageName, versionRange] of Object.entries(packageJson[dependencyType] || {})) {
+      const minimumVersion = semver.minVersion(versionRange)
+      if (!minimumVersion) {
+        throw new Error(`Could not determine minimum version for ${packageName} with version range ${versionRange}`)
+      }
+      packageJson[dependencyType][packageName] = minimumVersion.version
+    }
+  }
+
+  // Remove all optional dependencies, since they're supposed to be optional
+  packageJson.optionalDependencies = {}
+
+  await writeFile('package.json', JSON.stringify(packageJson, null, 2) + '\n', 'utf8')
+
+  const command = /** @type {const} */ ([
+    'npm',
+    'install'
+  ])
+
+  console.log(`Running command: ${command.join(' ')}`)
+
+  await execFileSync(command[0], command.slice(1), {
+    stdio: 'inherit'
+  })
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
## :bookmark_tabs: Summary

Bump `@mermaid-js/layout-elk` to `^0.1.5 || ^0.2`.

I've added a test in the CI that tries to install the minimum/oldest version of all of our dependencies, and it looks like https://github.com/mermaid-js/mermaid/pull/5825 was actually a hidden breaking change for `@mermaid-js/layout-elk` and `mermaid` v11.3.0.

## :straight_ruler: Design Decisions

This also adds a new test to the CI that tries to install the minimum version of all our `dependencies` and `peerDependencies` (as well as removing all `optionalDependencies`, once we have any of them).

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
