### PR TITLE
feat: add `@mermaid-js/layout-tidy-tree` support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,9 @@
       "engines": {
         "node": "^18.19 || >=20.0"
       },
+      "optionalDependencies": {
+        "@mermaid-js/layout-tidy-tree": "^0.2.1"
+      },
       "peerDependencies": {
         "puppeteer": "^23 || ^24"
       }
@@ -2082,6 +2085,19 @@
       "dependencies": {
         "d3": "^7.9.0",
         "elkjs": "^0.9.3"
+      },
+      "peerDependencies": {
+        "mermaid": "^11.0.2"
+      }
+    },
+    "node_modules/@mermaid-js/layout-tidy-tree": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/layout-tidy-tree/-/layout-tidy-tree-0.2.1.tgz",
+      "integrity": "sha512-LZFmu6SZmAR5N/aesR7ya5JwEjCrGh7J64n7vFmHqVDHDJjIx+LsEi0dmt0WTYbP4wdKFLLykpvRsemRgAnLXA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "d3": "^7.9.0"
       },
       "peerDependencies": {
         "mermaid": "^11.0.2"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "import-meta-resolve": "^4.1.0",
     "mermaid": "^11.14.0"
   },
+  "optionalDependencies": {
+    "@mermaid-js/layout-tidy-tree": "^0.2.1"
+  },
   "peerDependencies": {
     "puppeteer": "^23 || ^24"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -270,8 +270,11 @@ async function renderMermaid (browser, definition, outputFormat, { viewport, bac
     await page.setRequestInterception(true)
 
     const metadata = await page.$eval('#container', async (container, { definition, mermaidConfig, myCSS, backgroundColor, svgId, iconPacks, iconPacksNamesAndUrls, elkUrl, mermaidUrl, zenumlUrl }) => {
+      /** @type {typeof import('mermaid')} */
       const { default: mermaid } = await import(mermaidUrl)
+      /** @type {typeof import('@mermaid-js/layout-elk')} */
       const { default: elkLayouts } = await import(elkUrl)
+      /** @type {typeof import('@mermaid-js/mermaid-zenuml')} */
       const { default: zenuml } = await import(zenumlUrl)
       await Promise.all(Array.from(document.fonts, (font) => font.load()))
 

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,18 @@ const mermaidESMPath = path.resolve(path.dirname(url.fileURLToPath(resolve('merm
 const elkESMPath = path.resolve(path.dirname(url.fileURLToPath(resolve('@mermaid-js/layout-elk', import.meta.url))), 'mermaid-layout-elk.esm.mjs')
 const zenumlESMPath = path.resolve(path.dirname(url.fileURLToPath(resolve('@mermaid-js/mermaid-zenuml', import.meta.url))), 'mermaid-zenuml.esm.mjs')
 
+/** @type {string | undefined} Path to `@mermaid-js/layout-tidy-tree`, if it is installed */
+let tidyTreeESMPath
+try {
+  tidyTreeESMPath = path.resolve(path.dirname(url.fileURLToPath(resolve('@mermaid-js/layout-tidy-tree', import.meta.url))), 'mermaid-layout-tidy-tree.esm.mjs')
+} catch (error) {
+  if (error instanceof Error && 'code' in error && error.code === 'ERR_MODULE_NOT_FOUND') {
+    // optional dependency, this is normal
+  } else {
+    throw error
+  }
+}
+
 /**
  * Prints an error to stderr, then closes with exit code 1
  *
@@ -265,21 +277,28 @@ async function renderMermaid (browser, definition, outputFormat, { viewport, bac
     const mermaidUrl = await interceptor.fileUrlToInterceptUrl(url.pathToFileURL(mermaidESMPath))
     const elkUrl = await interceptor.fileUrlToInterceptUrl(url.pathToFileURL(elkESMPath))
     const zenumlUrl = await interceptor.fileUrlToInterceptUrl(url.pathToFileURL(zenumlESMPath))
+    const tidyTreeESMUrl = tidyTreeESMPath ? await interceptor.fileUrlToInterceptUrl(url.pathToFileURL(tidyTreeESMPath)) : undefined
 
     page.on('request', interceptor.interceptRequestHandler)
     await page.setRequestInterception(true)
 
-    const metadata = await page.$eval('#container', async (container, { definition, mermaidConfig, myCSS, backgroundColor, svgId, iconPacks, iconPacksNamesAndUrls, elkUrl, mermaidUrl, zenumlUrl }) => {
+    const metadata = await page.$eval('#container', async (container, { definition, mermaidConfig, myCSS, backgroundColor, svgId, iconPacks, iconPacksNamesAndUrls, elkUrl, mermaidUrl, zenumlUrl, tidyTreeESMUrl }) => {
       /** @type {typeof import('mermaid')} */
       const { default: mermaid } = await import(mermaidUrl)
       /** @type {typeof import('@mermaid-js/layout-elk')} */
       const { default: elkLayouts } = await import(elkUrl)
       /** @type {typeof import('@mermaid-js/mermaid-zenuml')} */
       const { default: zenuml } = await import(zenumlUrl)
+      // @ts-ignore -- @mermaid-js/layout-tidy-tree is an optionalDependency and might not be installed
+      /** @type {typeof import('@mermaid-js/layout-tidy-tree') | {default: undefined}} */
+      const { default: tidyTree } = tidyTreeESMUrl ? await import(tidyTreeESMUrl) : { default: undefined }
       await Promise.all(Array.from(document.fonts, (font) => font.load()))
 
       await mermaid.registerExternalDiagrams([zenuml])
-      mermaid.registerLayoutLoaders(elkLayouts)
+      mermaid.registerLayoutLoaders([
+        ...elkLayouts,
+        ...(tidyTree ?? [])
+      ])
       // lazy load icon packs
 
       mermaid.registerIconPacks(
@@ -348,7 +367,7 @@ async function renderMermaid (browser, definition, outputFormat, { viewport, bac
       return {
         title, desc
       }
-    }, { definition, mermaidConfig, myCSS, backgroundColor, svgId, iconPacks, iconPacksNamesAndUrls, elkUrl, mermaidUrl, zenumlUrl })
+    }, { definition, mermaidConfig, myCSS, backgroundColor, svgId, iconPacks, iconPacksNamesAndUrls, elkUrl, mermaidUrl, zenumlUrl, tidyTreeESMUrl })
 
     if (outputFormat === 'svg') {
       const svgXML = await page.$eval('svg', (svg) => {

--- a/test-positive/mindmap-tidy-tree.mmd
+++ b/test-positive/mindmap-tidy-tree.mmd
@@ -1,0 +1,10 @@
+---
+config:
+  layout: tidy-tree
+---
+mindmap
+    root((Mindmap using tidy-tree layout))
+        A
+        B
+        C
+        D


### PR DESCRIPTION
## :bookmark_tabs: Summary

Add support for mindmaps using the tidy-tree layout, see https://mermaid.js.org/config/tidy-tree.html

## :straight_ruler: Design Decisions

I've made this an `optionalDependency`, so if anybody wants to exclude it for any reason (as it's not included in mermaid by default), they can.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
