### PR TITLE
fix: handle a race-condition when writing the file in `run()` Node.JS API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import { resolve } from 'import-meta-resolve'
 import path from 'path'
 import puppeteer from 'puppeteer'
 import url from 'url'
+import { promisify } from 'node:util'
 import { version } from './version.js'
 import { Interceptor } from './puppeteerIntercept.js'
 
@@ -548,9 +549,11 @@ async function run (input, output, { puppeteerConfig = {}, quiet = false, output
       info('Generating single mermaid chart')
       browser = await puppeteer.launch(puppeteerConfig)
       const { data } = await renderMermaid(browser, definition, outputFormat, parseMMDOptions)
-      await output !== '/dev/stdout'
-        ? fs.promises.writeFile(output, data)
-        : process.stdout.write(data)
+      if (output === '/dev/stdout') {
+        await promisify(process.stdout.write).call(process.stdout, data)
+      } else {
+        await fs.promises.writeFile(output, data)
+      }
     }
   } finally {
     await browser?.close?.()


### PR DESCRIPTION
## :bookmark_tabs: Summary

The `await` wasn't actually waiting for the file to finish writing, so in extremely rare cases (maybe slow storage devices/network storage), the browser might close before the write has finished.

## :straight_ruler: Design Decisions

I switched this to using an `if` statement to make it a bit easier to read!

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
