### PR TITLE
feat: add `--jobs` to limit parallel diagram renders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "chalk": "^5.0.1",
         "commander": "^13.1.0",
         "import-meta-resolve": "^4.1.0",
-        "mermaid": "^11.14.0"
+        "mermaid": "^11.14.0",
+        "p-limit": "^6.2.0"
       },
       "bin": {
         "mmdc": "src/cli.js"
@@ -6140,6 +6141,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint/node_modules/p-locate": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
@@ -6149,6 +6166,19 @@
       "dependencies": {
         "p-limit": "^3.0.2"
       },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -7725,6 +7755,35 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-changed-files/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/jest-circus": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.2.0.tgz",
@@ -7772,6 +7831,35 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-circus/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-circus/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-cli": {
@@ -8292,6 +8380,35 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-runner/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-runner/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-runtime": {
@@ -9417,16 +9534,15 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+      "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
       "license": "MIT",
       "dependencies": {
-        "yocto-queue": "^0.1.0"
+        "yocto-queue": "^1.1.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -12238,13 +12354,12 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "chalk": "^5.0.1",
     "commander": "^13.1.0",
     "import-meta-resolve": "^4.1.0",
-    "mermaid": "^11.14.0"
+    "mermaid": "^11.14.0",
+    "p-limit": "^6.2.0"
   },
   "peerDependencies": {
     "puppeteer": "^23 || ^24"

--- a/src-test/test.js
+++ b/src-test/test.js
@@ -343,7 +343,7 @@ describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {
       )
 
       await run(
-        'test-positive/mermaid.md', expectedOutputMd, { limiter, quiet: true, outputFormat: 'svg', artefacts: artefact ? './test-output/svg/dist/' : undefined }
+        'test-positive/mermaid.md', expectedOutputMd, { browser, limiter, quiet: true, outputFormat: 'svg', artefacts: artefact ? './test-output/svg/dist/' : undefined }
       )
 
       const markdownFile = await fs.readFile(expectedOutputMd, { encoding: 'utf8' })
@@ -370,7 +370,7 @@ describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {
       )
 
       await run(
-        'test-positive/mermaid.md', expectedOutputMd, { limiter, quiet: true, outputFormat: 'png' }
+        'test-positive/mermaid.md', expectedOutputMd, { browser, limiter, quiet: true, outputFormat: 'png' }
       )
 
       const markdownFile = await fs.readFile(expectedOutputMd, { encoding: 'utf8' })
@@ -402,7 +402,7 @@ describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {
       await run(
         'test-positive/flowchart1.mmd',
         expectedOutput,
-        { limiter, quiet: true, outputFormat: format }
+        { browser, limiter, quiet: true, outputFormat: format }
       )
       expectBytesAreFormat(await fs.readFile(expectedOutput), format)
     }, timeout)
@@ -426,7 +426,7 @@ describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {
         const runConcurrently = !/\.(md|markdown)$/.test(file);
         (runConcurrently ? test.concurrent : test).each(formats)(`${shouldError ? 'should fail' : 'should compile'} ${file} to format %s`, async (format) => {
           const result = file.replace(/\.(?:mmd|md|markdown)$/, `-run.${format}`)
-          const promise = run(join(workflow, file), join(out, result), { limiter, quiet: true })
+          const promise = run(join(workflow, file), join(out, result), { browser, limiter, quiet: true })
           if (shouldError) {
             await expect(promise).rejects.toThrow()
           } else {

--- a/src-test/test.js
+++ b/src-test/test.js
@@ -11,6 +11,8 @@ import { promisify } from 'util'
 import { expect, beforeAll, afterAll, describe, test } from '@jest/globals'
 
 import { run, renderMermaid } from '../src/index.js'
+import os from 'os'
+import pLimit from 'p-limit'
 import puppeteer from 'puppeteer'
 import { pipeline } from 'stream'
 
@@ -56,7 +58,8 @@ async function compileDiagram (workflow, file, format, { puppeteerConfigFile } =
     '-c',
     join(workflow, 'config.json'),
     '-b',
-    'lightgray'
+    'lightgray',
+    '--jobs=2'
   ]
 
   if (puppeteerConfigFile) {
@@ -92,6 +95,10 @@ function expectBytesAreFormat (bytes, fileType) {
       throw new Error('Unsupported filetype')
   }
 }
+
+// This is double the default limit in mermaid-cli, but for testing, we have
+// very small diagrams, so that should be okay from a performance standpoint.
+const limiter = pLimit(os.availableParallelism())
 
 let browser
 beforeAll(async () => {
@@ -336,7 +343,7 @@ describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {
       )
 
       await run(
-        'test-positive/mermaid.md', expectedOutputMd, { quiet: true, outputFormat: 'svg', artefacts: artefact ? './test-output/svg/dist/' : undefined }
+        'test-positive/mermaid.md', expectedOutputMd, { limiter, quiet: true, outputFormat: 'svg', artefacts: artefact ? './test-output/svg/dist/' : undefined }
       )
 
       const markdownFile = await fs.readFile(expectedOutputMd, { encoding: 'utf8' })
@@ -363,7 +370,7 @@ describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {
       )
 
       await run(
-        'test-positive/mermaid.md', expectedOutputMd, { quiet: true, outputFormat: 'png' }
+        'test-positive/mermaid.md', expectedOutputMd, { limiter, quiet: true, outputFormat: 'png' }
       )
 
       const markdownFile = await fs.readFile(expectedOutputMd, { encoding: 'utf8' })
@@ -395,7 +402,7 @@ describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {
       await run(
         'test-positive/flowchart1.mmd',
         expectedOutput,
-        { quiet: true, outputFormat: format }
+        { limiter, quiet: true, outputFormat: format }
       )
       expectBytesAreFormat(await fs.readFile(expectedOutput), format)
     }, timeout)
@@ -419,7 +426,7 @@ describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {
         const runConcurrently = !/\.(md|markdown)$/.test(file);
         (runConcurrently ? test.concurrent : test).each(formats)(`${shouldError ? 'should fail' : 'should compile'} ${file} to format %s`, async (format) => {
           const result = file.replace(/\.(?:mmd|md|markdown)$/, `-run.${format}`)
-          const promise = run(join(workflow, file), join(out, result), { quiet: true })
+          const promise = run(join(workflow, file), join(out, result), { limiter, quiet: true })
           if (shouldError) {
             await expect(promise).rejects.toThrow()
           } else {

--- a/src/index.js
+++ b/src/index.js
@@ -452,10 +452,12 @@ function markdownImage ({ url, title, alt }) {
  * @param {"svg" | "png" | "pdf"} [opts.outputFormat] - Mermaid output format.
  * @param {string} [opts.artefacts] - Path to the artefacts directory.
  * Defaults to `output` extension. Overrides `output` extension if set.
+ * @param {import("puppeteer").Browser} [opts.browser] - If set, reuses the given puppeteer browser instance instead of creating a new one.
+ * This may leak cookies/cache between runs.
  * @param {Limiter} [opts.limiter] - If set, limiter function to avoid rendering too many diagrams in parallel.
  * @param {ParseMDDOptions} [opts.parseMMDOptions] - Options to pass to {@link parseMMDOptions}.
  */
-async function run (input, output, { puppeteerConfig = {}, quiet = false, outputFormat, parseMMDOptions, limiter = (x, ...args) => x(...args), artefacts } = {}) {
+async function run (input, output, { browser: userPassedBrowser, puppeteerConfig = {}, quiet = false, outputFormat, parseMMDOptions, limiter = (x, ...args) => x(...args), artefacts } = {}) {
   /**
    * Logs the given message to stdout, unless `quiet` is set to `true`.
    *
@@ -474,7 +476,7 @@ async function run (input, output, { puppeteerConfig = {}, quiet = false, output
    * @type {puppeteer.Browser | undefined}
    * Lazy-loaded browser instance, only created when needed.
    */
-  let browser
+  let browser = userPassedBrowser
   try {
     if (!outputFormat) {
       const outputFormatFromFilename =
@@ -561,7 +563,7 @@ async function run (input, output, { puppeteerConfig = {}, quiet = false, output
       }
     } else {
       info('Generating single mermaid chart')
-      browser = await puppeteer.launch(puppeteerConfig)
+      browser ??= await puppeteer.launch(puppeteerConfig)
       const { data } = await renderMermaid(browser, definition, outputFormat, parseMMDOptions)
       if (output === '/dev/stdout') {
         await promisify(process.stdout.write).call(process.stdout, data)
@@ -570,7 +572,10 @@ async function run (input, output, { puppeteerConfig = {}, quiet = false, output
       }
     }
   } finally {
-    await browser?.close?.()
+    // Don't close the browser if it was passed in by the user
+    if (browser !== userPassedBrowser) {
+      await browser?.close?.()
+    }
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,9 @@ import { Command, Option, InvalidArgumentError } from 'commander'
 import chalk from 'chalk'
 import fs from 'fs'
 import { resolve } from 'import-meta-resolve'
+import os from 'node:os'
 import path from 'path'
+import pLimit from 'p-limit'
 import puppeteer from 'puppeteer'
 import url from 'url'
 import { promisify } from 'node:util'
@@ -114,6 +116,9 @@ async function cli () {
     .option('-i, --input <input>', 'Input mermaid file. Files ending in .md will be treated as Markdown and all charts (e.g. ```mermaid (...)``` or :::mermaid (...):::) will be extracted and generated. Use `-` to read from stdin.')
     .option('-o, --output [output]', 'Output file. It should be either md, svg, png, pdf or use `-` to output to stdout. Optional. Default: input + ".svg"')
     .option('-a, --artefacts [artefacts]', 'Output artefacts path. Only used with Markdown input file. Optional. Default: output directory')
+    .addOption(new Option('-j, --jobs <jobs>', 'Number of parallel jobs to run when rendering multiple diagrams. Defaults to half the available CPUs.').argParser(parseCommanderInt).default(
+      Math.floor(os.availableParallelism() / 2) || 1
+    ))
     .addOption(new Option('-e, --outputFormat [format]', 'Output format for the generated image.').choices(['svg', 'png', 'pdf']).default(null, 'Loaded from the output file extension'))
     .addOption(new Option('-b, --backgroundColor [backgroundColor]', 'Background color for pngs/svgs (not pdfs). Example: transparent, red, \'#F0F0F0\'.').default('white'))
     .option('-c, --configFile [configFile]', 'JSON configuration file for mermaid.')
@@ -129,7 +134,7 @@ async function cli () {
 
   const options = commander.opts()
 
-  let { theme, width, height, input, output, outputFormat, backgroundColor, configFile, cssFile, svgId, puppeteerConfigFile, scale, pdfFit, quiet, iconPacks, iconPacksNamesAndUrls, artefacts } = options
+  let { theme, width, height, input, output, outputFormat, backgroundColor, configFile, cssFile, svgId, puppeteerConfigFile, scale, pdfFit, quiet, iconPacks, iconPacksNamesAndUrls, artefacts, jobs } = options
 
   // check input file
   if (!input) {
@@ -218,6 +223,7 @@ async function cli () {
       puppeteerConfig,
       quiet,
       outputFormat,
+      limiter: pLimit(jobs),
       parseMMDOptions: {
         mermaidConfig, backgroundColor, myCSS, pdfFit, viewport: { width, height, deviceScaleFactor: scale }, svgId, iconPacks, iconPacksNamesAndUrls
       },
@@ -426,6 +432,13 @@ function markdownImage ({ url, title, alt }) {
 }
 
 /**
+ * @typedef {<Arguments extends unknown[], ReturnType>(
+ *  function_: (...arguments_: Arguments) => Promise<ReturnType>,
+ *    ...arguments_: Arguments
+ * ) => Promise<ReturnType>} Limiter - Adapted from `p-limit` package.
+ */
+
+/**
  * Renders a mermaid diagram or mermaid markdown file.
  *
  * @param {`${string}.${"md" | "markdown"}` | string | undefined} input - If this ends with `.md`/`.markdown`,
@@ -439,9 +452,10 @@ function markdownImage ({ url, title, alt }) {
  * @param {"svg" | "png" | "pdf"} [opts.outputFormat] - Mermaid output format.
  * @param {string} [opts.artefacts] - Path to the artefacts directory.
  * Defaults to `output` extension. Overrides `output` extension if set.
+ * @param {Limiter} [opts.limiter] - If set, limiter function to avoid rendering too many diagrams in parallel.
  * @param {ParseMDDOptions} [opts.parseMMDOptions] - Options to pass to {@link parseMMDOptions}.
  */
-async function run (input, output, { puppeteerConfig = {}, quiet = false, outputFormat, parseMMDOptions, artefacts } = {}) {
+async function run (input, output, { puppeteerConfig = {}, quiet = false, outputFormat, parseMMDOptions, limiter = (x, ...args) => x(...args), artefacts } = {}) {
   /**
    * Logs the given message to stdout, unless `quiet` is set to `true`.
    *
@@ -509,7 +523,7 @@ async function run (input, output, { puppeteerConfig = {}, quiet = false, output
 
         const outputFileRelative = `./${path.relative(path.dirname(path.resolve(output)), path.resolve(outputFile))}`
 
-        const imagePromise = (async () => {
+        const imagePromise = limiter(async (browser, outputFormat) => {
           const { title, desc, data } = await renderMermaid(browser, mermaidDefinition, outputFormat, parseMMDOptions)
           await fs.promises.writeFile(outputFile, data)
           info(` ✅ ${outputFileRelative}`)
@@ -519,7 +533,7 @@ async function run (input, output, { puppeteerConfig = {}, quiet = false, output
             title,
             alt: desc
           }
-        })()
+        }, browser, outputFormat)
         imagePromises.push(imagePromise)
       }
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

Add a new `-j, --jobs [number]` option to control the number of parallel mermaid renders to use when rendering a `.md` markdown file with multiple mermaid diagrams.

By default, half of the available CPUs are used, since browser pages are quite CPU and RAM intensive.

## :straight_ruler: Design Decisions

I've also allowed passing an existing Puppeteer browser to `run()`.

I don't think users should use this, since if they were using the Node.JS API like this directly and were worried about performance like this, they'd ideally call the `renderMermaid()` function directly. But it does mean that we can use it to optimize our tests!

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
