### PR TITLE
ci: run some E2E tests on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
+      fail-fast: false # our tests are a bit flaky in CI
       matrix:
         node: [ 18.19 ]
         dependencies:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,20 +4,30 @@ on: [push, pull_request]
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash # Use bash even on Windows
+
 jobs:
   test:
-    name: Test Node.js ${{ matrix.node }} with ${{ matrix.dependencies }} dependencies
-    runs-on: ubuntu-latest
+    name: Test Node.js ${{ matrix.node }} with ${{ matrix.dependencies }} dependencies on ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
       fail-fast: false # our tests are a bit flaky in CI
       matrix:
         node: [ 18.19 ]
+        os:
+          - ubuntu-latest
+          - windows-latest
         dependencies:
           # default `package-lock.json` dependencies
           - 'default'
-          # install with oldest dependencies without optional dependencies
-          - 'minimal'
+        include:
+          # test with minimal dependencies (only puppeteer-core and its dependencies)
+          - node: 18.19
+            os: ubuntu-latest
+            dependencies: 'minimal'
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.JS ${{ matrix.node }}
@@ -49,4 +59,11 @@ jobs:
       # We use aa-exec since Ubuntu 24.04's AppArmor profile blocks the use
       # of puppeteer otherwise, see
       # https://github.com/puppeteer/puppeteer/issues/12818
-      - run: aa-exec --profile=chrome npm test
+      - name: Run tests
+        run: |
+          is_ubuntu=$(node -e 'console.log(os.platform() === "linux" && os.version().toLowerCase().includes("ubuntu"));')
+          if [ "$is_ubuntu" = "true" ]; then
+            aa-exec --profile=chrome npm test
+          else
+            npm test
+          fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@fortawesome/fontawesome-free": "^7.0.1",
         "@tsconfig/node18": "^18.2.4",
         "@types/node": "~18.19.31",
+        "cross-env": "^7.0.3",
         "jest": "^30.0.5",
         "puppeteer": "^24.0.0",
         "standard": "^17.0.0",
@@ -4531,6 +4532,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "prepare": "tsc && vite build",
     "prepack": "tsc && vite build",
-    "test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest",
+    "test": "cross-env-shell NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest",
     "test:cli": "bash run-tests.sh test-positive",
     "version": "node scripts/version.js",
     "lint": "standard",
@@ -47,6 +47,7 @@
     "@fortawesome/fontawesome-free": "^7.0.1",
     "@tsconfig/node18": "^18.2.4",
     "@types/node": "~18.19.31",
+    "cross-env": "^7.0.3",
     "jest": "^30.0.5",
     "puppeteer": "^24.0.0",
     "standard": "^17.0.0",

--- a/src-test/test.js
+++ b/src-test/test.js
@@ -400,7 +400,7 @@ describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {
       expect(markdownFile).toContain(markdownImageWithCustomTitle)
 
       // check whether newlines before/after mermaid diagram are kept
-      expect(markdownFile).toContain('There should be an empty newline after this line, but before the Mermaid diagram:\n\n')
+      expect(markdownFile).toMatch(/There should be an empty newline after this line, but before the Mermaid diagram:\r?\n\r?\n/)
 
       // files should exist, and they should be PNGs
       await Promise.all(expectedOutputPngs.map(async (expectedOutputPng) => {


### PR DESCRIPTION
## :bookmark_tabs: Summary

Start running our tests in CI using Windows.

This might be important to make sure that we handle file paths (e.g. `\` and `/`), as well as `\r\n` vs `\n` correctly.

## :straight_ruler: Design Decisions

Now that we're running the tests three times on each push, I've disabled `strategy.fail-fast` for this job, in case there is any flakiness.

This is also the reason why I'm not running the windows tests with `dependencies: 'minimal'`, since it's unlikely to catch any additional bugs, but it might cause additional flakiness/slow-down in CI.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
