### PR TITLE
ci(release): improve the `release-publish.yml` workflow

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -46,7 +46,7 @@ jobs:
         run: echo "RELEASE_VERSION=${{ steps.gitversion.outputs.semVer }}" >> $GITHUB_ENV
 
       - name: Prepare release
-        run: npm version --no-git-tag-version --allow-same-version ${{env.RELEASE_VERSION}}
+        run: npm version --no-git-tag-version --allow-same-version "$RELEASE_VERSION"
 
       - name: Convert repository name to lower case
         run: echo "GITHUB_REPOSITORY_LOWER_CASE=$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
@@ -95,14 +95,14 @@ jobs:
 
       - name: Post deployment tests
         run: |
-          for i in $(ls test-positive/*.mmd); do docker run -v $(pwd):/data ${{env.DOCKER_IO_REPOSITORY}}:${{env.RELEASE_VERSION}} -i /data/$i; done
-          for i in $(ls test-positive/*.mmd); do cat $i | docker run -i -v $(pwd):/data ${{env.DOCKER_IO_REPOSITORY}}:${{env.RELEASE_VERSION}} -o /data/$i-stdin.svg; done
+          for i in test-positive/*.mmd; do docker run -v "$(pwd):/data" "$DOCKER_IO_REPOSITORY:$RELEASE_VERSION" -i "/data/$i"; done
+          for i in test-positive/*.mmd; do cat "$i" | docker run -i -v "$(pwd):/data" "$DOCKER_IO_REPOSITORY:$RELEASE_VERSION" -o "/data/$i-stdin.svg"; done
 
       - name: Commit new version to the repository
         run: |
           git add package.json package-lock.json
           git checkout master
-          git commit -m "Bump version ${{env.RELEASE_VERSION}}"
+          git commit -m "Bump version $RELEASE_VERSION"
           git push --no-verify
 
       # For manual inspection of the generated artifacts

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 permissions:
-  contents: read
+  contents: write # needed to push the commit with the new version to the repository
   id-token: write
   packages: write
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
-          cache: npm
+          package-manager-cache: false
           registry-url: https://registry.npmjs.org/
       - name: Build the package
         # throws an error if package-lock.json is out-of-date

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Commit new version to the repository
         run: |
-          git add package.json
+          git add package.json package-lock.json
           git checkout master
           git commit -m "Bump version ${{env.RELEASE_VERSION}}"
           git push --no-verify


### PR DESCRIPTION
## :bookmark_tabs: Summary

Various fixes for the `release-publish.yml` workflow, including:

1. Adding the `contents: write` permission, as it's required to push the new version commit.
2. Including the `package-lock.json` file in the new version commit.
3. Quoting bash variables correctly
4. Disabling the `actions/setup-node` cache to avoid cache poisoning attacks.

## :straight_ruler: Design Decisions

N/A

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
