### PR TITLE
perf: stop bundling FontAwesome/KaTeX CSS & fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,13 +3,6 @@
   <body>
     <div id="container"></div>
     <script type="module">
-      // don't import minified CSS files (e.g. `*.min.css`), since that actually
-      // makes the dist/index.html slightly larger!
-      import "@fortawesome/fontawesome-free/css/brands.css"
-      import "@fortawesome/fontawesome-free/css/regular.css"
-      import "@fortawesome/fontawesome-free/css/solid.css"
-      import "@fortawesome/fontawesome-free/css/fontawesome.css"
-      import "katex/dist/katex.css"
     </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,5 @@
 <html>
   <body>
     <div id="container"></div>
-    <script type="module">
-    </script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "11.12.0",
       "license": "MIT",
       "dependencies": {
+        "@fortawesome/fontawesome-free": "^6.0.0 || ^7.0.1",
         "@mermaid-js/layout-elk": "^0.1.5 || ^0.2.0",
         "@mermaid-js/mermaid-zenuml": "^0.2.0",
         "chalk": "^5.0.1",
         "commander": "^13.1.0",
         "import-meta-resolve": "^4.1.0",
+        "katex": "^0.16.25",
         "mermaid": "^11.14.0",
         "p-limit": "^6.2.0"
       },
@@ -21,7 +23,6 @@
         "mmdc": "src/cli.js"
       },
       "devDependencies": {
-        "@fortawesome/fontawesome-free": "^7.0.1",
         "@tsconfig/node18": "^18.2.4",
         "@types/node": "~18.19.31",
         "cross-env": "^7.0.3",
@@ -1190,7 +1191,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.0.1.tgz",
       "integrity": "sha512-RLmb9U6H2rJDnGxEqXxzy7ANPrQz7WK2/eTjdZqyU9uRU5W+FkAec9uU5gTYzFBH7aoXIw2WTJSCJR4KPlReQw==",
-      "dev": true,
       "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
       "engines": {
         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
     "lint-fix": "standard --fix"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^6.0.0 || ^7.0.1",
     "@mermaid-js/layout-elk": "^0.1.5 || ^0.2.0",
     "@mermaid-js/mermaid-zenuml": "^0.2.0",
     "chalk": "^5.0.1",
     "commander": "^13.1.0",
     "import-meta-resolve": "^4.1.0",
+    "katex": "^0.16.25",
     "mermaid": "^11.14.0",
     "p-limit": "^6.2.0"
   },
@@ -44,7 +46,6 @@
     "puppeteer": "^23 || ^24"
   },
   "devDependencies": {
-    "@fortawesome/fontawesome-free": "^7.0.1",
     "@tsconfig/node18": "^18.2.4",
     "@types/node": "~18.19.31",
     "cross-env": "^7.0.3",

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,17 @@ import { Interceptor } from './puppeteerIntercept.js'
 const __dirname = url.fileURLToPath(new url.URL('.', import.meta.url))
 
 /**
+ * CSS paths to embed in the page.
+ */
+const cssImports = /** @type {const} */ ({
+  '@fortawesome/fontawesome-free/css/brands.css': { level: 2 },
+  '@fortawesome/fontawesome-free/css/regular.css': { level: 2 },
+  '@fortawesome/fontawesome-free/css/solid.css': { level: 2 },
+  '@fortawesome/fontawesome-free/css/fontawesome.css': { level: 2 },
+  'katex/dist/katex.css': { level: 2 }
+})
+
+/**
  * ESM bundles. Our interceptor doesn't support loading ESM modules that load
  * other modules using relative paths, so these have to no `dependencies`.
  */
@@ -305,8 +316,16 @@ async function renderMermaid (browser, definition, outputFormat, { viewport, bac
     page.on('request', interceptor.interceptRequestHandler)
     await page.setRequestInterception(true)
 
+    await Promise.all(Object.entries(cssImports).map(async ([cssImport, { level }]) => {
+      const interceptUrl = await interceptor.fileUrlToInterceptUrl(new URL(resolve(cssImport, import.meta.url)), {
+        allowParentDirectoryLevel: level
+      })
+      await page.addStyleTag({
+        url: interceptUrl
+      })
+    }))
+
     const metadata = await page.$eval('#container', async (container, { definition, mermaidConfig, myCSS, backgroundColor, svgId, iconPacks, iconPacksNamesAndUrls, elkUrl, mermaidUrl, zenumlUrl, tidyTreeESMUrl }) => {
-      /** @type {typeof import('mermaid')} */
       const { default: mermaid } = await import(mermaidUrl)
       /** @type {typeof import('@mermaid-js/layout-elk')} */
       const { default: elkLayouts } = await import(elkUrl)

--- a/src/puppeteerIntercept.js
+++ b/src/puppeteerIntercept.js
@@ -7,6 +7,29 @@ import path from 'node:path'
 import url from 'node:url'
 
 /**
+ * Guesses the MIME-type of a file based on its extension.
+ *
+ * I've hardcoded the bare minimum number of MIME-types to support for security reasons.
+ *
+ * @param {string} filePath - The file path to guess the MIME-type for.
+ */
+function getContentTypeFromFileExtension (filePath) {
+  const ext = path.extname(filePath).toLowerCase()
+  switch (ext) {
+    case '.css':
+      // Make sure to set UTF-8, since sometimes Puppeteer can parse it as Latin-1.
+      return 'text/css;charset=UTF-8'
+    case '.js':
+    case '.mjs':
+      return 'application/javascript'
+    case '.woff2':
+      return 'font/woff2'
+    default:
+      throw new Error(`Unsupported file extension for intercept: ${ext}`)
+  }
+}
+
+/**
  * Puppeteer doesn't allow importing ESM modules from `file://` URLs.
  * We don't want to create a dummy http server to serve ESM modules
  * (since that would cause issues with ports/firewalls), so this module
@@ -27,14 +50,22 @@ export class Interceptor {
   #allowedDirs = new Set()
 
   /**
-     * @param {URL | `file://${string}`} fileUrl - File URL
-     */
-  async fileUrlToInterceptUrl (fileUrl) {
+   * @param {URL | `file://${string}`} fileUrl - File URL
+   * @param {Object} [options] - Optional options.
+   * @param {number} [options.allowParentDirectoryLevel] - Number of parent directory levels to allow access to.
+   */
+  async fileUrlToInterceptUrl (fileUrl, {
+    allowParentDirectoryLevel = 1
+  } = {}) {
     fileUrl = new URL(fileUrl)
     if (fileUrl.protocol !== 'file:') {
       throw new Error(`Invalid file URL: ${fileUrl}`)
     }
-    this.#allowedDirs.add(path.dirname(await realpath(url.fileURLToPath(fileUrl))))
+    let parentDirectory = await realpath(url.fileURLToPath(fileUrl))
+    while (allowParentDirectoryLevel-- >= 0) {
+      parentDirectory = path.dirname(parentDirectory)
+    }
+    this.#allowedDirs.add(parentDirectory)
     return `${this.#INTERCEPT_ORIGIN}${fileUrl.pathname}`
   }
 
@@ -68,7 +99,7 @@ export class Interceptor {
           headers: {
             'Access-Control-Allow-Origin': '*'
           },
-          contentType: 'application/javascript',
+          contentType: getContentTypeFromFileExtension(url.fileURLToPath(fileUrl)),
           body: await readFile(fileUrl)
         })
       }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,27 +2,4 @@ import { defineConfig } from "vite"
 
 export default defineConfig({
   base: './',
-  plugins: [
-    {
-      name: 'IIFE-converter',
-      config(currentConfig, _unused) {
-        return {
-          ...currentConfig,
-          build: {
-            ...currentConfig.build,
-            rollupOptions: {
-              ...currentConfig.build?.rollupOptions,
-              output: {
-                ...currentConfig.build?.rollupOptions?.output,
-                format: 'iife',
-              }
-            }
-          }
-        };
-      },
-      transformIndexHtml(html) {
-        return html.replace('<script type="module" crossorigin', '<script charset="utf-8"')
-      }
-    }
-  ]
 });


### PR DESCRIPTION
## :bookmark_tabs: Summary

Stop bundling FontAwesome/KaTeX CSS and fonts at build time, and instead load them at runtime. This means that users can pick their own versions of FontAwesome and KaTeX.

This meant that we had to update our intercepter to support CSS files and WOFF2 files.

## :straight_ruler: Design Decisions

The `index.html` file is not very useful right now, and could be removed in the future. I've kept it as it is temporarily, in case there's a new mermaid feature that might need it in the future.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
  - Covered by existing unit/e2e tests, ideally @Percy shouldn't spot any differences
- [x] :bookmark: targeted `master` branch
