### PR TITLE
ci(release): move version bump earlier in the current workflow

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -48,6 +48,19 @@ jobs:
       - name: Prepare release
         run: npm version --no-git-tag-version --allow-same-version "$RELEASE_VERSION"
 
+      - name: Commit new version and update release tag
+        run: |
+          git add package.json package-lock.json src/version.js
+          git checkout master
+          if git diff --cached --quiet; then
+            echo "Version files are already up to date"
+          else
+            git commit -m "Bump version $RELEASE_VERSION"
+            git push --no-verify origin master
+          fi
+          git tag --force "${{ github.event.release.tag_name }}" HEAD
+          git push --no-verify --force origin "${{ github.event.release.tag_name }}"
+
       - name: Convert repository name to lower case
         run: echo "GITHUB_REPOSITORY_LOWER_CASE=$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
@@ -97,13 +110,6 @@ jobs:
         run: |
           for i in test-positive/*.mmd; do docker run -v "$(pwd):/data" "$DOCKER_IO_REPOSITORY:$RELEASE_VERSION" -i "/data/$i"; done
           for i in test-positive/*.mmd; do cat "$i" | docker run -i -v "$(pwd):/data" "$DOCKER_IO_REPOSITORY:$RELEASE_VERSION" -o "/data/$i-stdin.svg"; done
-
-      - name: Commit new version to the repository
-        run: |
-          git add package.json package-lock.json
-          git checkout master
-          git commit -m "Bump version $RELEASE_VERSION"
-          git push --no-verify
 
       # For manual inspection of the generated artifacts
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -46,20 +46,25 @@ jobs:
         run: echo "RELEASE_VERSION=${{ steps.gitversion.outputs.semVer }}" >> $GITHUB_ENV
 
       - name: Prepare release
-        run: npm version --no-git-tag-version --allow-same-version "$RELEASE_VERSION"
-
-      - name: Commit new version and update release tag
         run: |
-          git add package.json package-lock.json src/version.js
-          git checkout master
-          if git diff --cached --quiet; then
-            echo "Version files are already up to date"
-          else
-            git commit -m "Bump version $RELEASE_VERSION"
-            git push --no-verify origin master
+          release_tag="${{ github.event.release.tag_name }}"
+          old_release_tag_ref="$(git rev-parse "refs/tags/$release_tag")"
+
+          if [ "$release_tag" != "$RELEASE_VERSION" ]; then
+            echo "Release tag '$release_tag' does not match version '$RELEASE_VERSION'"
+            exit 1
           fi
-          git tag --force "${{ github.event.release.tag_name }}" HEAD
-          git push --no-verify --force origin "${{ github.event.release.tag_name }}"
+
+          npm version \
+            --allow-same-version \
+            --tag-version-prefix "" \
+            --message "Bump version %s" \
+            "$RELEASE_VERSION"
+
+          echo "RELEASE_COMMIT=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+          git push --no-verify \
+            --force-with-lease="refs/tags/$release_tag:$old_release_tag_ref" \
+            origin "refs/tags/$release_tag"
 
       - name: Convert repository name to lower case
         run: echo "GITHUB_REPOSITORY_LOWER_CASE=$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
@@ -110,6 +115,15 @@ jobs:
         run: |
           for i in test-positive/*.mmd; do docker run -v "$(pwd):/data" "$DOCKER_IO_REPOSITORY:$RELEASE_VERSION" -i "/data/$i"; done
           for i in test-positive/*.mmd; do cat "$i" | docker run -i -v "$(pwd):/data" "$DOCKER_IO_REPOSITORY:$RELEASE_VERSION" -o "/data/$i-stdin.svg"; done
+
+      - name: Update default branch to release commit
+        continue-on-error: true
+        run: |
+          default_branch="${{ github.event.repository.default_branch }}"
+          git fetch origin "$default_branch"
+          git checkout -B "$default_branch" "origin/$default_branch"
+          git merge --ff-only "$RELEASE_COMMIT"
+          git push --no-verify origin "$default_branch"
 
       # For manual inspection of the generated artifacts
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -46,8 +46,9 @@ jobs:
         run: echo "RELEASE_VERSION=${{ steps.gitversion.outputs.semVer }}" >> $GITHUB_ENV
 
       - name: Prepare release
+        env:
+          release_tag: ${{ github.event.release.tag_name }}
         run: |
-          release_tag="${{ github.event.release.tag_name }}"
           old_release_tag_ref="$(git rev-parse "refs/tags/$release_tag")"
 
           if [ "$release_tag" != "$RELEASE_VERSION" ]; then
@@ -119,11 +120,11 @@ jobs:
       - name: Update default branch to release commit
         continue-on-error: true
         run: |
-          default_branch="${{ github.event.repository.default_branch }}"
-          git fetch origin "$default_branch"
-          git checkout -B "$default_branch" "origin/$default_branch"
+          git switch "$DEFAULT_BRANCH"
           git merge --ff-only "$RELEASE_COMMIT"
-          git push --no-verify origin "$default_branch"
+          git push --no-verify
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
       # For manual inspection of the generated artifacts
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary

Fix release tags by moving the existing version bump earlier in the current `release.published` workflow.

Currently `release-publish.yml` runs after a GitHub release is published. The workflow updates `package.json`, `package-lock.json`, and `src/version.js`, but it commits those changes after npm/Docker publishing and after the release tag already exists. As a result, release source archives can contain stale metadata such as `11.12.0` in the `11.15.0` tag.

This minimal option keeps the existing release trigger and release-drafter/manual-publish flow.

  ## Changes

  - Use `npm version` to create the version bump commit and tag.
  - Preserve the existing non-`v` tag format with `--tag-version-prefix ""`.
  - Validate that the GitHub release tag matches the computed release version.
  - Push the updated release tag with `--force-with-lease`.
  - After publishing and post-deployment tests, try to fast-forward the repository default branch to the release commit.
  - Make the default branch update non-blocking so it does not fail npm or Docker publishing if the release tag was not based on the default branch.

  ## Tradeoff

  This still updates the GitHub release tag after publication, so release source archive SHAs can change for users who downloaded them immediately. Avoiding that completely would require
  changing the release process so the version bump commit and tag are created before publishing the GitHub release.

## Why

The npm package and Docker image are built from the updated working tree, but GitHub release tags/source archives currently point to the pre-version-bump commit. Downstream consumers that build from release tags therefore see stale version metadata and may need to patch the package so `mmdc --version` matches the release.

This is the smallest change to the current workflow, but it does require updating a tag after GitHub has already created it for the published release.

Fixes https://github.com/mermaid-js/mermaid-cli/issues/697