### PR TITLE
Fix Issue #1063 Option 2

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,8 +1,12 @@
 name: Publish release
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version. Leave empty to use GitVersion."
+        required: false
+        type: string
 
 permissions:
   contents: write # needed to push the commit with the new version to the repository
@@ -22,6 +26,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          ref: master
       - uses: fregante/setup-git-user@024bc0b8e177d7e77203b48dab6fb45666854b35 # v2.0.2
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -43,10 +48,36 @@ jobs:
         uses: gittools/actions/gitversion/execute@51d325634925d7d9ce0a7efc2c586c0bc2b9eee6 # v3.2.1
 
       - name: Get release version
-        run: echo "RELEASE_VERSION=${{ steps.gitversion.outputs.semVer }}" >> $GITHUB_ENV
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            echo "RELEASE_VERSION=${{ inputs.version }}" >> "$GITHUB_ENV"
+          else
+            echo "RELEASE_VERSION=${{ steps.gitversion.outputs.semVer }}" >> "$GITHUB_ENV"
+          fi
 
       - name: Prepare release
         run: npm version --no-git-tag-version --allow-same-version "$RELEASE_VERSION"
+
+      - name: Commit new version and create release tag
+        run: |
+          git add package.json package-lock.json src/version.js
+          if git diff --cached --quiet; then
+            echo "Version files are already up to date"
+          else
+            git commit -m "Bump version $RELEASE_VERSION"
+          fi
+          git tag "$RELEASE_VERSION"
+          git push --no-verify origin master "$RELEASE_VERSION"
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$RELEASE_VERSION" >/dev/null 2>&1; then
+            gh release edit "$RELEASE_VERSION" --draft=false --latest
+          else
+            gh release create "$RELEASE_VERSION" --title "$RELEASE_VERSION" --generate-notes --latest
+          fi
 
       - name: Convert repository name to lower case
         run: echo "GITHUB_REPOSITORY_LOWER_CASE=$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
@@ -97,13 +128,6 @@ jobs:
         run: |
           for i in test-positive/*.mmd; do docker run -v "$(pwd):/data" "$DOCKER_IO_REPOSITORY:$RELEASE_VERSION" -i "/data/$i"; done
           for i in test-positive/*.mmd; do cat "$i" | docker run -i -v "$(pwd):/data" "$DOCKER_IO_REPOSITORY:$RELEASE_VERSION" -o "/data/$i-stdin.svg"; done
-
-      - name: Commit new version to the repository
-        run: |
-          git add package.json package-lock.json
-          git checkout master
-          git commit -m "Bump version $RELEASE_VERSION"
-          git push --no-verify
 
       # For manual inspection of the generated artifacts
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary

Fix release tags by making the publish workflow create the version bump commit and tag before publishing the GitHub release.

Currently `release-publish.yml` runs after a GitHub release is published. The workflow updates `package.json`, `package-lock.json`, and `src/version.js`, but it commits those changes after npm/Docker publishing and after the release tag already exists. As a result, release source archives can contain stale metadata such as `11.12.0` in the `11.15.0` tag.

This cleaner option changes the release workflow so the tag is created only after the version bump commit exists.

## Changes

- Change the publish workflow from `release.published` to `workflow_dispatch`.
- Check out `master` explicitly.
- Accept an optional manual release version, otherwise use GitVersion.
- Run `npm version --no-git-tag-version`.
- Commit `package.json`, `package-lock.json`, and `src/version.js`.
- Create the release tag at that commit and push both `master` and the tag.
- Publish or create the GitHub release from that tag.
- Publish npm and Docker artifacts from the same versioned checkout.

## Why

The npm package and Docker image are built from the updated working tree, but GitHub release tags/source archives currently point to the pre-version-bump commit. Downstream consumers that build from release tags therefore see stale version metadata and may need to patch the package so `mmdc --version` matches the release.

This avoids force-updating an already-published release tag. The tag is created once, after the version bump commit exists and before any artifacts are published.

Closes https://github.com/mermaid-js/mermaid-cli/issues/1063