### PR TITLE
ci: improve zip file handling in `upload-percy.yml`

### DIFF
--- a/.github/workflows/upload-percy.yml
+++ b/.github/workflows/upload-percy.yml
@@ -49,11 +49,15 @@ jobs:
             });
             const fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/mmdc-output.zip', Buffer.from(download.data));
-      - run: unzip mmdc-output.zip
+      - run: |
+          # Use `-j` to avoid zip slip/directory structure issues.
+          unzip -j mmdc-output.zip -d ./output
+          # Filter out irregular files like symlinks
+          find ./output -mindepth 1 -maxdepth 1 ! -type f -exec rm -- {} +
       - name: "Upload to Percy"
         # copied from https://docs.percy.io/docs/github-actions
         # should automatically upload `.png`
-        run: npx @percy/cli upload ./
+        run: npx @percy/cli upload ./output
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
           # Because we are not running on pull_request, but from a workflow_run,


### PR DESCRIPTION
## :bookmark_tabs: Summary

Add more protections against invalid or malicious zip files uploaded to the `upload-percy.yml` file.

Although our PERCY_TOKEN is low-risk (the only thing a user could do with it is DoS it, which they can do anyway with a large enough `.zip` file), this adds additional protection against leaking it.

Currently, a malicious user could upload a malicious `node_modules` file that would make `npx @percy/cli` run arbitrary code.

Thanks to @izefoea for reporting this issue!

## :straight_ruler: Design Decisions

I've used the `-j` flag of `unzip` to remove all directory structure issues, and output everything into an `./output` folder.

`unzip` does not allow filtering out symlinks, so afterwards, I'm running a basic `find ./output -mindepth 1 -maxdepth 1 ! -type f -exec rm -- {} +` to remove all irregular files (e.g. like symlinks).

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
