### PR TITLE
feat: use puppeteer cooperative intercepts

### DIFF
--- a/src-test/test.js
+++ b/src-test/test.js
@@ -13,7 +13,7 @@ import { expect, beforeAll, afterAll, describe, test } from "@jest/globals";
 import { run, renderMermaid } from "../src/index.js";
 import os from "os";
 import pLimit from "p-limit";
-import puppeteer from "puppeteer";
+import puppeteer, { DEFAULT_INTERCEPT_RESOLUTION_PRIORITY } from "puppeteer";
 import { pipeline } from "stream";
 
 const workflows = ["test-positive", "test-negative"];
@@ -112,6 +112,7 @@ function expectBytesAreFormat(bytes, fileType) {
 // very small diagrams, so that should be okay from a performance standpoint.
 const limiter = pLimit(os.availableParallelism());
 
+/** @type {import('puppeteer').Browser} */
 let browser;
 beforeAll(async () => {
   browser = await puppeteer.launch({ headless: "shell" });
@@ -799,5 +800,35 @@ describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {
       },
       timeout,
     );
+
+    test("should allow custom request interceptors", async () => {
+      const context = await browser.createBrowserContext();
+      context.on("targetcreated", async (target) => {
+        const page = await target.page();
+        if (!page) {
+          return;
+        }
+        page.setRequestInterception(true);
+        page.on("request", (request) => {
+          if (request.url().includes("example.test")) {
+            request.respond(
+              {
+                status: 200,
+                contentType: "image/svg+xml",
+                body: `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><circle r="45" cx="50" cy="50" fill="red" /></svg>`,
+              },
+              DEFAULT_INTERCEPT_RESOLUTION_PRIORITY,
+            );
+          } else {
+            request.continue(undefined, DEFAULT_INTERCEPT_RESOLUTION_PRIORITY);
+          }
+        });
+      });
+
+      const mmdInput =
+        'flowchart TD\n    A --> B[<img src="https://example.test/icon.svg" />]';
+      const result = await renderMermaid(context, mmdInput, "png");
+      expectBytesAreFormat(result.data, "png");
+    });
   });
 });

--- a/src-test/test.js
+++ b/src-test/test.js
@@ -801,34 +801,41 @@ describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {
       timeout,
     );
 
-    test("should allow custom request interceptors", async () => {
-      const context = await browser.createBrowserContext();
-      context.on("targetcreated", async (target) => {
-        const page = await target.page();
-        if (!page) {
-          return;
-        }
-        page.setRequestInterception(true);
-        page.on("request", (request) => {
-          if (request.url().includes("example.test")) {
-            request.respond(
-              {
-                status: 200,
-                contentType: "image/svg+xml",
-                body: `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><circle r="45" cx="50" cy="50" fill="red" /></svg>`,
-              },
-              DEFAULT_INTERCEPT_RESOLUTION_PRIORITY,
-            );
-          } else {
-            request.continue(undefined, DEFAULT_INTERCEPT_RESOLUTION_PRIORITY);
+    test(
+      "should allow custom request interceptors",
+      async () => {
+        const context = await browser.createBrowserContext();
+        context.on("targetcreated", async (target) => {
+          const page = await target.page();
+          if (!page) {
+            return;
           }
+          page.setRequestInterception(true);
+          page.on("request", (request) => {
+            if (request.url().includes("example.test")) {
+              request.respond(
+                {
+                  status: 200,
+                  contentType: "image/svg+xml",
+                  body: `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><circle r="45" cx="50" cy="50" fill="red" /></svg>`,
+                },
+                DEFAULT_INTERCEPT_RESOLUTION_PRIORITY,
+              );
+            } else {
+              request.continue(
+                undefined,
+                DEFAULT_INTERCEPT_RESOLUTION_PRIORITY,
+              );
+            }
+          });
         });
-      });
 
-      const mmdInput =
-        'flowchart TD\n    A --> B[<img src="https://example.test/icon.svg" />]';
-      const result = await renderMermaid(context, mmdInput, "png");
-      expectBytesAreFormat(result.data, "png");
-    });
+        const mmdInput =
+          'flowchart TD\n    A --> B[<img src="https://example.test/icon.svg" />]';
+        const result = await renderMermaid(context, mmdInput, "png");
+        expectBytesAreFormat(result.data, "png");
+      },
+      timeout,
+    );
   });
 });

--- a/src/puppeteerIntercept.js
+++ b/src/puppeteerIntercept.js
@@ -5,6 +5,7 @@
 import { readFile, realpath } from "node:fs/promises";
 import path from "node:path";
 import url from "node:url";
+import { DEFAULT_INTERCEPT_RESOLUTION_PRIORITY } from "puppeteer";
 
 /**
  * Guesses the MIME-type of a file based on its extension.
@@ -101,25 +102,28 @@ export class Interceptor {
     try {
       if (request.url().startsWith(this.#INTERCEPT_ORIGIN)) {
         const fileUrl = await this.interceptUrlToFileUrl(request.url());
-        return request.respond({
-          status: 200,
-          headers: {
-            "Access-Control-Allow-Origin": "*",
+        return request.respond(
+          {
+            status: 200,
+            headers: {
+              "Access-Control-Allow-Origin": "*",
+            },
+            contentType: getContentTypeFromFileExtension(
+              url.fileURLToPath(fileUrl),
+            ),
+            body: await readFile(fileUrl),
           },
-          contentType: getContentTypeFromFileExtension(
-            url.fileURLToPath(fileUrl),
-          ),
-          body: await readFile(fileUrl),
-        });
+          DEFAULT_INTERCEPT_RESOLUTION_PRIORITY,
+        );
       }
     } catch (error) {
       console.error(
         `Error handling intercept request for ${request.url()}:`,
         error,
       );
-      request.abort();
+      request.abort(undefined, DEFAULT_INTERCEPT_RESOLUTION_PRIORITY);
     }
-    request.continue();
+    request.continue(undefined, DEFAULT_INTERCEPT_RESOLUTION_PRIORITY);
   }
 
   /**

--- a/src/puppeteerIntercept.js
+++ b/src/puppeteerIntercept.js
@@ -121,7 +121,7 @@ export class Interceptor {
         `Error handling intercept request for ${request.url()}:`,
         error,
       );
-      request.abort(undefined, DEFAULT_INTERCEPT_RESOLUTION_PRIORITY);
+      return request.abort(undefined, DEFAULT_INTERCEPT_RESOLUTION_PRIORITY);
     }
     request.continue(undefined, DEFAULT_INTERCEPT_RESOLUTION_PRIORITY);
   }


### PR DESCRIPTION
## :bookmark_tabs: Summary

Set the `DEFAULT_INTERCEPT_RESOLUTION_PRIORITY` priority for our Puppeteer interceptor, switching it to a cooperative intercept.

This allows Node.JS API library users of the `mermaid-cli` library to add their own request interceptors on top of our interceptor.

See: https://pptr.dev/guides/network-interception

## :straight_ruler: Design Decisions

This code works with Puppeteer v23.0.0, so it's compatible with all versions we support.

Additionally, existing users of our Node.JS API couldn't use any interceptors, so we don't have to worry about breaking changes for those users.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
