### PR TITLE
test: add missing timeout to Iconify icon pack tests

### DIFF
--- a/src-test/test.js
+++ b/src-test/test.js
@@ -768,28 +768,36 @@ describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {
       expectBytesAreFormat(result.data, "svg");
     });
 
-    test("should show Iconify icon packs", async () => {
-      const mmdInput = "architecture-beta\n    group aws(logos:aws)[AWS]";
-      const result = await renderMermaid(browser, mmdInput, "svg", {
-        iconPacks: ["@iconify-json/logos"],
-      });
-      expectBytesAreFormat(result.data, "svg");
-      const decoder = new TextDecoder();
-      expect(decoder.decode(result.data)).toContain("<path");
-    }, timeout);
+    test(
+      "should show Iconify icon packs",
+      async () => {
+        const mmdInput = "architecture-beta\n    group aws(logos:aws)[AWS]";
+        const result = await renderMermaid(browser, mmdInput, "svg", {
+          iconPacks: ["@iconify-json/logos"],
+        });
+        expectBytesAreFormat(result.data, "svg");
+        const decoder = new TextDecoder();
+        expect(decoder.decode(result.data)).toContain("<path");
+      },
+      timeout,
+    );
 
-    test("should show Iconify icon packs and named iconpacks", async () => {
-      const mmdInput =
-        'flowchart TD\n    aws@{ icon: "logos:aws" } \n    resource-groups@{ icon: "azure:resource-groups", label: "resource-groups" }';
-      const result = await renderMermaid(browser, mmdInput, "svg", {
-        iconPacks: ["@iconify-json/logos"],
-        iconPacksNamesAndUrls: [
-          "azure#https://raw.githubusercontent.com/NakayamaKento/AzureIcons/refs/heads/main/icons.json",
-        ],
-      });
-      expectBytesAreFormat(result.data, "svg");
-      const decoder = new TextDecoder();
-      expect(decoder.decode(result.data)).toContain("<path");
-    }, timeout);
+    test(
+      "should show Iconify icon packs and named iconpacks",
+      async () => {
+        const mmdInput =
+          'flowchart TD\n    aws@{ icon: "logos:aws" } \n    resource-groups@{ icon: "azure:resource-groups", label: "resource-groups" }';
+        const result = await renderMermaid(browser, mmdInput, "svg", {
+          iconPacks: ["@iconify-json/logos"],
+          iconPacksNamesAndUrls: [
+            "azure#https://raw.githubusercontent.com/NakayamaKento/AzureIcons/refs/heads/main/icons.json",
+          ],
+        });
+        expectBytesAreFormat(result.data, "svg");
+        const decoder = new TextDecoder();
+        expect(decoder.decode(result.data)).toContain("<path");
+      },
+      timeout,
+    );
   });
 });

--- a/src-test/test.js
+++ b/src-test/test.js
@@ -776,7 +776,7 @@ describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {
       expectBytesAreFormat(result.data, "svg");
       const decoder = new TextDecoder();
       expect(decoder.decode(result.data)).toContain("<path");
-    });
+    }, timeout);
 
     test("should show Iconify icon packs and named iconpacks", async () => {
       const mmdInput =
@@ -790,6 +790,6 @@ describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {
       expectBytesAreFormat(result.data, "svg");
       const decoder = new TextDecoder();
       expect(decoder.decode(result.data)).toContain("<path");
-    });
+    }, timeout);
   });
 });


### PR DESCRIPTION
## :bookmark_tabs: Summary

Two tests in src-test/test.js were missing the timeout constant (60000ms) that the rest of the test suite uses, causing them to consistently fail with Jest's default 5000ms timeout when running npm test.

---

Resolves #1104

---

## :straight_ruler: Design Decisions
The fix simply adds timeout as the third argument to both failing tests, consistent with how every other test in the file is written. No logic changes were made.

Make sure you

- [-] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [-] :computer: have added unit/e2e tests (if appropriate)
- [-] :bookmark: targeted `master` branch
