### PR TITLE
feat: add --keep-source to retain mermaid source in Markdown output

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,76 @@ Becomes:
 ![My description here](./readme-3.svg "My title here")
 ```
 
+### Keep the mermaid source (`--keep-source`)
+
+By default the mermaid source is replaced by the generated image. With
+`--keep-source` the source is kept in the output too, wrapped in round-trip
+markers, so you can edit the diagram and re-render in place. This applies to
+Markdown input and output only. Running the command again on its own output is
+idempotent — the existing image and source are replaced together, never nested.
+
+```sh
+mmdc -i readme.md -o readme.md --keep-source
+```
+
+Each diagram becomes:
+
+````md
+<!-- mermaid:begin -->
+
+![diagram](./readme-1.svg)
+
+```mermaid
+graph TD
+   [....]
+```
+
+<!-- mermaid:end -->
+````
+
+The default layout is plain Markdown that renders anywhere. Alternatively,
+`--source-style collapsed` hides the source behind a collapsible HTML
+`<details>` block:
+
+```sh
+mmdc -i readme.md -o readme.md --keep-source --source-style collapsed
+```
+
+Each diagram becomes:
+
+````md
+<!-- mermaid:begin -->
+
+![diagram](./readme-1.svg)
+<details>
+<summary>Diagram source</summary>
+
+```mermaid
+graph TD
+   [....]
+```
+
+</details>
+<!-- mermaid:end -->
+````
+
+The optional `--source-summary <text>` changes the label of the collapsible
+block from the default `Diagram source`.
+
+Each style has one caveat. On hosts that render mermaid natively (GitHub,
+GitLab), the `plain` style shows each diagram twice — the generated image plus
+the natively rendered fence — so prefer `collapsed` there. Conversely, the
+`collapsed` style relies on raw HTML, so it only renders where your Markdown
+host allows HTML (GitHub, GitLab, and most static-site generators); in viewers
+that strip HTML the tags show up literally — use the default `plain` style
+there.
+
+Running `mmdc` _without_ `--keep-source` on a file that contains keep-source
+regions converts each region back to a plain image — the same output as if
+`--keep-source` had never been used. This removes the embedded mermaid source
+from the document, so `mmdc` prints a warning when it happens; keep using the
+flag if you want to retain the source.
+
 ### Piping from stdin
 
 You can easily pipe input from stdin. This example shows how to use a heredoc to

--- a/src-test/test.js
+++ b/src-test/test.js
@@ -11,6 +11,14 @@ import { promisify } from "util";
 import { expect, beforeAll, afterAll, describe, test } from "@jest/globals";
 
 import { run, renderMermaid } from "../src/index.js";
+import {
+  KEEP_SOURCE_PRESETS,
+  createKeepSourceRegex,
+  resolveKeepSourceTemplate,
+  sourceFromMatch,
+  applyKeepSourceTemplate,
+  hasKeepSourceMarkers,
+} from "../src/keep-source.js";
 import os from "os";
 import pLimit from "p-limit";
 import puppeteer, { DEFAULT_INTERCEPT_RESOLUTION_PRIORITY } from "puppeteer";
@@ -660,6 +668,252 @@ describe("NodeJS API (import ... from '@mermaid-js/mermaid-cli')", () => {
       },
       timeout,
     );
+
+    test(
+      "should keep the mermaid source and re-render idempotently with keepSource",
+      async () => {
+        const outputMd = "test-output/mermaid-keep-source.md";
+        await fs.rm(outputMd, { force: true });
+
+        const options = {
+          browser,
+          limiter,
+          quiet: true,
+          outputFormat: "svg",
+          keepSource: true,
+          sourceStyle: "plain",
+        };
+
+        // First run: bare ```mermaid fences -> image + marker-wrapped source.
+        await run("test-positive/mermaid.md", outputMd, options);
+        const firstPass = await fs.readFile(outputMd, { encoding: "utf8" });
+
+        // The source is kept (not discarded), wrapped in round-trip markers,
+        // alongside a generated image.
+        expect(firstPass).toContain("<!-- mermaid:begin -->");
+        expect(firstPass).toContain("<!-- mermaid:end -->");
+        expect(firstPass).toContain("```mermaid");
+        expect(firstPass).toMatch(
+          /!\[[^\]]*\]\(\.\/mermaid-keep-source-1\.svg/,
+        );
+
+        const beginMarkers = firstPass.match(/<!-- mermaid:begin -->/g) || [];
+        const fences = firstPass.match(/```mermaid/g) || [];
+        expect(beginMarkers.length).toBeGreaterThan(0);
+
+        // Second run on the tool's own output must be a no-op for the Markdown
+        // (the whole marker region is replaced, never nested).
+        await run(outputMd, outputMd, options);
+        const secondPass = await fs.readFile(outputMd, { encoding: "utf8" });
+
+        expect(secondPass).toEqual(firstPass);
+        expect(secondPass.match(/<!-- mermaid:begin -->/g) || []).toHaveLength(
+          beginMarkers.length,
+        );
+        expect(secondPass.match(/```mermaid/g) || []).toHaveLength(
+          fences.length,
+        );
+      },
+      timeout,
+    );
+
+    test(
+      "should support the collapsed source style with a custom summary",
+      async () => {
+        // A single diagram suffices here: the collapsed layout and its
+        // round-trip are style concerns, not regex-edge-case concerns (the
+        // plain and strip tests cover those against the full fixture).
+        const inputMd = "test-output/keep-source-collapsed-input.md";
+        await fs.writeFile(
+          inputMd,
+          "# Title\n\n```mermaid\ngraph TD\n  A-->B\n```\n",
+        );
+        const outputMd = "test-output/mermaid-keep-source-collapsed.md";
+        await fs.rm(outputMd, { force: true });
+
+        const options = {
+          browser,
+          limiter,
+          quiet: true,
+          outputFormat: "svg",
+          keepSource: true,
+          sourceStyle: "collapsed",
+          sourceSummary: "Show diagram source",
+        };
+
+        await run(inputMd, outputMd, options);
+        const firstPass = await fs.readFile(outputMd, { encoding: "utf8" });
+        expect(firstPass).toContain("<details>");
+        expect(firstPass).toContain("<summary>Show diagram source</summary>");
+
+        await run(outputMd, outputMd, options);
+        const secondPass = await fs.readFile(outputMd, { encoding: "utf8" });
+        expect(secondPass).toEqual(firstPass);
+        // exactly as many <details> as diagrams: no nesting on re-run
+        expect(secondPass.match(/<details>/g) || []).toHaveLength(
+          firstPass.match(/<details>/g).length,
+        );
+      },
+      timeout,
+    );
+
+    test(
+      "keepSource output is stable under Prettier (no formatter churn)",
+      async () => {
+        const prettier = await import("prettier");
+        const inputMd = "test-output/keep-source-prettier-input.md";
+        await fs.writeFile(
+          inputMd,
+          "# Title\n\n```mermaid\ngraph TD\n  A-->B\n```\n",
+        );
+
+        for (const sourceStyle of ["plain", "collapsed"]) {
+          const outputMd = `test-output/keep-source-prettier-${sourceStyle}.md`;
+          await fs.rm(outputMd, { force: true });
+          await run(inputMd, outputMd, {
+            browser,
+            limiter,
+            quiet: true,
+            outputFormat: "svg",
+            keepSource: true,
+            sourceStyle,
+          });
+
+          const output = await fs.readFile(outputMd, { encoding: "utf8" });
+          // Running Prettier over the emitted Markdown must be a no-op, so the
+          // tool's output does not fight a formatter in the user's repo.
+          const formatted = await prettier.format(output, {
+            parser: "markdown",
+          });
+          expect(formatted).toEqual(output);
+        }
+      },
+      timeout,
+    );
+
+    test(
+      "running without keepSource converts keep-source output back to plain output",
+      async () => {
+        const plainMd = "test-output/keep-source-strip-plain.md";
+        const keptMd = "test-output/keep-source-strip-kept.md";
+        await fs.rm(plainMd, { force: true });
+        await fs.rm(keptMd, { force: true });
+
+        const options = { browser, limiter, quiet: true, outputFormat: "svg" };
+
+        // Reference: render the input without keepSource.
+        await run("test-positive/mermaid.md", plainMd, options);
+        const plain = await fs.readFile(plainMd, { encoding: "utf8" });
+
+        // Render with keepSource, then re-run without the flag in place: the
+        // regions must collapse back to plain images, not accumulate wrappers.
+        await run("test-positive/mermaid.md", keptMd, {
+          ...options,
+          keepSource: true,
+        });
+        await run(keptMd, keptMd, options);
+        const stripped = await fs.readFile(keptMd, { encoding: "utf8" });
+
+        // No markers survive. (Can't assert on ```mermaid: the fixture
+        // mentions it in prose.)
+        expect(stripped).not.toContain("<!-- mermaid:begin -->");
+        expect(stripped).not.toContain("<!-- mermaid:end -->");
+        // Identical to never having used keepSource, modulo the image
+        // filenames, which derive from the output filename.
+        expect(
+          stripped.replaceAll(
+            "keep-source-strip-kept",
+            "keep-source-strip-plain",
+          ),
+        ).toEqual(plain);
+      },
+      timeout,
+    );
+
+    // The following exercise the keep-source regex/template directly (no
+    // rendering), so they are fast and deterministic.
+    describe("keep-source regex/template internals", () => {
+      test("captures a bare fence with CRLF line endings", () => {
+        const md = ["```mermaid", "graph TD", "  A-->B", "```", ""].join(
+          "\r\n",
+        );
+        const sources = [...md.matchAll(createKeepSourceRegex())].map(
+          sourceFromMatch,
+        );
+        expect(sources).toHaveLength(1);
+        expect(sources[0]).toContain("graph TD");
+      });
+
+      test("does not swallow a following diagram when a marker is missing", () => {
+        // The first region is missing its `mermaid:end` marker.
+        const md = [
+          "<!-- mermaid:begin -->",
+          "![](a.svg)",
+          "```mermaid",
+          "AAA",
+          "```",
+          "<!-- mermaid:begin -->",
+          "![](b.svg)",
+          "```mermaid",
+          "BBB",
+          "```",
+          "<!-- mermaid:end -->",
+        ].join("\n");
+        const sources = [...md.matchAll(createKeepSourceRegex())]
+          .map(sourceFromMatch)
+          .map((s) => s.trim());
+        // Both diagrams survive rather than one being consumed by the other.
+        expect(sources).toEqual(["AAA", "BBB"]);
+      });
+
+      test("matches in linear time on a begin marker with no matching end (ReDoS guard)", () => {
+        // Regression guard for catastrophic backtracking: a large input with
+        // begin markers + fences but no end markers must complete quickly.
+        const md = "<!-- mermaid:begin -->\n```mermaid\nX\n```\n".repeat(4000);
+        const start = Date.now();
+        const count = [...md.matchAll(createKeepSourceRegex())].length;
+        expect(count).toBe(4000);
+        expect(Date.now() - start).toBeLessThan(2000);
+      });
+
+      test("resolveKeepSourceTemplate resolves style presets and defaults to plain", () => {
+        expect(resolveKeepSourceTemplate("collapsed")).toBe(
+          KEEP_SOURCE_PRESETS.collapsed,
+        );
+        expect(resolveKeepSourceTemplate("plain")).toBe(
+          KEEP_SOURCE_PRESETS.plain,
+        );
+        expect(resolveKeepSourceTemplate(undefined)).toBe(
+          KEEP_SOURCE_PRESETS.plain,
+        );
+      });
+
+      test("hasKeepSourceMarkers detects markers, including whitespace variants", () => {
+        expect(hasKeepSourceMarkers("# plain doc\n```mermaid\nA\n```")).toBe(
+          false,
+        );
+        expect(hasKeepSourceMarkers("<!-- mermaid:begin -->")).toBe(true);
+        expect(hasKeepSourceMarkers("text\n<!--mermaid:end-->\ntext")).toBe(
+          true,
+        );
+      });
+
+      test("resolveKeepSourceTemplate rejects an unknown style", () => {
+        expect(() => resolveKeepSourceTemplate("colapsed")).toThrow(
+          /Unknown sourceStyle "colapsed"/,
+        );
+      });
+
+      test("leaves unknown placeholders untouched and does not re-interpret values", () => {
+        const out = applyKeepSourceTemplate("{{image}} {{unknown}}", {
+          image: "$& {{source}}",
+        });
+        // Known placeholder substituted literally ($& not treated specially,
+        // and a {{source}} inside the value is not recursively expanded);
+        // unknown placeholder left as-is.
+        expect(out).toBe("$& {{source}} {{unknown}}");
+      });
+    });
 
     test.each(["svg", "png", "pdf"])(
       "should write %s from .mmd input",

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,14 @@ import url from "url";
 import { promisify } from "node:util";
 import { version } from "./version.js";
 import { Interceptor } from "./puppeteerIntercept.js";
+import {
+  createKeepSourceRegex,
+  resolveKeepSourceTemplate,
+  sourceFromMatch,
+  applyKeepSourceTemplate,
+  escapeHtml,
+  hasKeepSourceMarkers,
+} from "./keep-source.js";
 
 // __dirname is not available in ESM modules by default
 const __dirname = url.fileURLToPath(new url.URL(".", import.meta.url));
@@ -200,6 +208,24 @@ async function cli() {
       "-a, --artefacts [artefacts]",
       "Output artefacts path. Only used with Markdown input file. Optional. Default: output directory",
     )
+    .option(
+      "--keep-source",
+      "Keep the mermaid source in the Markdown output, wrapped in round-trip markers so it can be re-rendered idempotently. Only used with Markdown output.",
+      false,
+    )
+    .addOption(
+      new Option(
+        "--source-style <style>",
+        "Layout preset used with --keep-source.",
+      )
+        .choices(["plain", "collapsed"])
+        .default("plain"),
+    )
+    .option(
+      "--source-summary <text>",
+      "Summary label used by the 'collapsed' --source-style.",
+      "Diagram source",
+    )
     .addOption(
       new Option(
         "-j, --jobs <jobs>",
@@ -275,6 +301,9 @@ async function cli() {
     iconPacksNamesAndUrls,
     artefacts,
     jobs,
+    keepSource,
+    sourceStyle,
+    sourceSummary,
   } = options;
 
   // check input file
@@ -329,6 +358,12 @@ async function cli() {
     if (!fs.existsSync(artefacts)) {
       fs.mkdirSync(artefacts, { recursive: true });
     }
+  }
+
+  if (keepSource && !/\.(?:md|markdown)$/.test(output)) {
+    warn(
+      "--keep-source (and --source-* options) only apply to Markdown output; ignoring.",
+    );
   }
 
   const outputDir = path.dirname(output);
@@ -387,6 +422,9 @@ async function cli() {
       iconPacksNamesAndUrls,
     },
     artefacts,
+    keepSource,
+    sourceStyle,
+    sourceSummary,
   });
 }
 
@@ -717,6 +755,9 @@ function markdownImage({ url, title, alt }) {
  * This may leak cookies/cache between runs.
  * @param {Limiter} [opts.limiter] - If set, limiter function to avoid rendering too many diagrams in parallel.
  * @param {ParseMDDOptions} [opts.parseMMDOptions] - Options to pass to {@link parseMMDOptions}.
+ * @param {boolean} [opts.keepSource] - If set, keep the mermaid source in the Markdown output (wrapped in round-trip markers) instead of replacing it with only an image. Only used with Markdown output.
+ * @param {"plain" | "collapsed"} [opts.sourceStyle] - Layout preset used with `keepSource`.
+ * @param {string} [opts.sourceSummary] - Summary label used by the `collapsed` source style.
  */
 async function run(
   input,
@@ -729,6 +770,9 @@ async function run(
     parseMMDOptions,
     limiter = (x, ...args) => x(...args),
     artefacts,
+    keepSource = false,
+    sourceStyle = "plain",
+    sourceSummary = "Diagram source",
   } = {},
 ) {
   /**
@@ -743,12 +787,16 @@ async function run(
   };
 
   // TODO: should we use a Markdown parser like remark instead of rolling our own parser?
-  const mermaidChartsInMarkdown =
-    /^[^\S\n]*[`:]{3}(?:mermaid)([^\S\n]*\r?\n([\s\S]*?))[`:]{3}[^\S\n]*$/;
-  const mermaidChartsInMarkdownRegexGlobal = new RegExp(
-    mermaidChartsInMarkdown,
-    "gm",
-  );
+  // Matches bare ```mermaid fences as well as whole regions previously emitted
+  // by --keep-source, so a re-run always replaces a region wholesale: with
+  // keepSource the source is kept alongside the fresh image, without it the
+  // region collapses back to a plain image — the same output as if
+  // --keep-source had never been used.
+  const markdownRegexGlobal = createKeepSourceRegex();
+  // Resolved eagerly so an invalid style fails before any rendering.
+  const keepSourceTemplate = keepSource
+    ? resolveKeepSourceTemplate(sourceStyle)
+    : "";
   /**
    * @type {import('puppeteer').Browser | undefined}
    * Lazy-loaded browser instance, only created when needed.
@@ -780,14 +828,26 @@ async function run(
         throw new Error("Cannot use `stdout` with markdown input");
       }
 
+      if (
+        !keepSource &&
+        /\.(md|markdown)$/.test(output) &&
+        hasKeepSourceMarkers(definition)
+      ) {
+        warn(
+          "The input contains keep-source regions but --keep-source is not set: " +
+            "each region will be converted back to a plain image and its embedded " +
+            "mermaid source removed. Use --keep-source to retain the source.",
+        );
+      }
+
       const imagePromises = [];
       for (const mermaidCodeblockMatch of definition.matchAll(
-        mermaidChartsInMarkdownRegexGlobal,
+        markdownRegexGlobal,
       )) {
         if (browser === undefined) {
           browser = await puppeteer.launch(puppeteerConfig);
         }
-        const mermaidDefinition = mermaidCodeblockMatch[2];
+        const mermaidDefinition = sourceFromMatch(mermaidCodeblockMatch);
 
         /** Output can be either a template image file, or a `.md` output file.
          *   If it is a template image file, use that to created numbered diagrams
@@ -842,8 +902,8 @@ async function run(
 
       if (/\.(md|markdown)$/.test(output)) {
         const outDefinition = definition.replace(
-          mermaidChartsInMarkdownRegexGlobal,
-          (_mermaidMd) => {
+          markdownRegexGlobal,
+          (...matchArgs) => {
             // pop first image from front of array
             const { url, title, alt } =
               /**
@@ -851,7 +911,16 @@ async function run(
                * so we will never try to get too many objects from the array.
                * (aka `images.shift()` will never return `undefined`)
                */ (images.shift());
-            return markdownImage({ url, title, alt: alt || "diagram" });
+            const image = markdownImage({ url, title, alt: alt || "diagram" });
+            if (!keepSource) {
+              return image;
+            }
+            const source = sourceFromMatch(matchArgs).replace(/\s+$/, "");
+            return applyKeepSourceTemplate(keepSourceTemplate, {
+              image,
+              source,
+              summary: escapeHtml(sourceSummary),
+            });
           },
         );
         await fs.promises.writeFile(output, outDefinition, "utf-8");

--- a/src/keep-source.js
+++ b/src/keep-source.js
@@ -1,0 +1,183 @@
+/**
+ * Machinery for the `--keep-source` feature: the round-trip markers, layout
+ * presets, the marker-aware regex, and template handling.
+ *
+ * Internal module: `package.json` only exports `src/index.js`, so nothing here
+ * is part of the public package API.
+ */
+
+/** Marker comments that delimit a `--keep-source` region so re-runs are idempotent. */
+const MERMAID_SOURCE_BEGIN = "<!-- mermaid:begin -->";
+const MERMAID_SOURCE_END = "<!-- mermaid:end -->";
+
+/** Matches a begin/end marker with the same whitespace tolerance as {@link createKeepSourceRegex}. */
+const BEGIN_MARKER_REGEX = /<!--[^\S\n]*mermaid:begin[^\S\n]*-->/;
+const END_MARKER_REGEX = /<!--[^\S\n]*mermaid:end[^\S\n]*-->/;
+
+/**
+ * Built-in layout presets for `--keep-source`. Every preset wraps the image and
+ * source inside the begin/end markers: the markers (not the visual layout) are
+ * what make re-runs idempotent, so they are always emitted regardless of preset.
+ * Placeholders: `{{image}}`, `{{source}}`, `{{summary}}`.
+ *
+ * The blank lines around the HTML-comment markers are deliberate: they keep the
+ * emitted Markdown stable under Prettier (and similar formatters), so running a
+ * formatter over the output does not introduce spurious diffs.
+ *
+ * @type {Record<string, string>}
+ */
+const KEEP_SOURCE_PRESETS = {
+  plain: [
+    MERMAID_SOURCE_BEGIN,
+    "",
+    "{{image}}",
+    "",
+    "```mermaid",
+    "{{source}}",
+    "```",
+    "",
+    MERMAID_SOURCE_END,
+  ].join("\n"),
+  collapsed: [
+    MERMAID_SOURCE_BEGIN,
+    "",
+    "{{image}}",
+    "<details>",
+    "<summary>{{summary}}</summary>",
+    "",
+    "```mermaid",
+    "{{source}}",
+    "```",
+    "",
+    "</details>",
+    MERMAID_SOURCE_END,
+  ].join("\n"),
+};
+
+/**
+ * Creates the regex used to find mermaid blocks in Markdown when `--keep-source`
+ * is enabled. It matches EITHER:
+ *   (a) a previously-emitted, marker-delimited region — consumed as a whole so a
+ *       re-run replaces the old image+source together and never nests a new
+ *       wrapper inside the old one (capture group 1 = source); OR
+ *   (b) a bare ```mermaid fence on the first run (capture group 2 = source).
+ *
+ * Every scan inside branch (a) is tempered with `notMarker` so it can never
+ * cross another begin/end marker. This keeps matching linear (no catastrophic
+ * backtracking on input that has a begin marker but no matching end) and stops
+ * one region from swallowing the diagrams that follow it when a marker is
+ * missing or malformed.
+ *
+ * A fresh instance is returned so each call gets its own `lastIndex`.
+ *
+ * @returns {RegExp} A new global, multiline regex.
+ */
+function createKeepSourceRegex() {
+  // A single character that does NOT start another mermaid:begin/end marker.
+  const notMarker =
+    "(?:(?!<!--[^\\S\\n]*mermaid:(?:begin|end)[^\\S\\n]*-->)[\\s\\S])";
+  return new RegExp(
+    "(?:" +
+      "<!--[^\\S\\n]*mermaid:begin[^\\S\\n]*-->" +
+      notMarker +
+      "*?" +
+      "[`:]{3}mermaid[^\\S\\n]*\\r?\\n(" +
+      notMarker +
+      "*?)\\r?\\n[^\\S\\n]*[`:]{3}[^\\S\\n]*" +
+      notMarker +
+      "*?" +
+      "<!--[^\\S\\n]*mermaid:end[^\\S\\n]*-->" +
+      ")|(?:" +
+      "^[^\\S\\n]*[`:]{3}mermaid[^\\S\\n]*\\r?\\n([\\s\\S]*?)[`:]{3}[^\\S\\n]*$" +
+      ")",
+    "gm",
+  );
+}
+
+/**
+ * Resolves the `--keep-source` layout template for a style preset. Presets are
+ * `{{placeholder}}` templates internally, so a user-facing custom-template
+ * option can be added here later without restructuring.
+ *
+ * @param {string} [sourceStyle] - Preset name (`plain` or `collapsed`).
+ * @returns {string} The preset template (always contains both markers).
+ * @throws {Error} If the style is unknown.
+ */
+function resolveKeepSourceTemplate(sourceStyle) {
+  const preset = KEEP_SOURCE_PRESETS[sourceStyle ?? "plain"];
+  if (!preset) {
+    throw new Error(
+      `Unknown sourceStyle "${sourceStyle}". ` +
+        `Expected one of: ${Object.keys(KEEP_SOURCE_PRESETS).join(", ")}.`,
+    );
+  }
+  return preset;
+}
+
+/**
+ * Whether the text contains a keep-source begin or end marker. Used to warn
+ * when a previously `--keep-source`-rendered file is re-rendered without the
+ * flag, which would duplicate the image and orphan the markers.
+ *
+ * @param {string} text - Markdown text to check.
+ * @returns {boolean} True if a begin or end marker is present.
+ */
+function hasKeepSourceMarkers(text) {
+  return BEGIN_MARKER_REGEX.test(text) || END_MARKER_REGEX.test(text);
+}
+
+/**
+ * Extracts the mermaid source from a match of {@link createKeepSourceRegex}:
+ * group 1 holds it for an existing marker-delimited region, group 2 for a bare
+ * fence. Keeps the group numbering knowledge next to the regex that defines it.
+ *
+ * @param {RegExpMatchArray | string[]} match - A match (or `String#replace`
+ * callback arguments) produced by the keep-source regex.
+ * @returns {string} The mermaid source.
+ */
+function sourceFromMatch(match) {
+  return /** @type {string} */ (match[1] ?? match[2]);
+}
+
+/**
+ * Interpolates `{{placeholder}}` tokens in a `--keep-source` template. Unknown
+ * placeholders are left untouched.
+ *
+ * @param {string} template - Template containing `{{name}}` placeholders.
+ * @param {Record<string, string>} vars - Values to substitute.
+ * @returns {string} The interpolated string.
+ */
+function applyKeepSourceTemplate(template, vars) {
+  return template.replace(/\{\{\s*(\w+)\s*\}\}/g, (match, key) =>
+    Object.prototype.hasOwnProperty.call(vars, key) ? vars[key] : match,
+  );
+}
+
+/**
+ * Escapes HTML metacharacters so a value can be safely placed in HTML text or
+ * an attribute (e.g. the `collapsed` preset's `<summary>`), without breaking
+ * the markup.
+ *
+ * @param {string} text - Raw text to escape.
+ * @returns {string} The escaped text.
+ */
+function escapeHtml(text) {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export {
+  MERMAID_SOURCE_BEGIN,
+  MERMAID_SOURCE_END,
+  KEEP_SOURCE_PRESETS,
+  createKeepSourceRegex,
+  resolveKeepSourceTemplate,
+  sourceFromMatch,
+  applyKeepSourceTemplate,
+  escapeHtml,
+  hasKeepSourceMarkers,
+};


### PR DESCRIPTION
## Motivation

When mermaid-cli transforms a Markdown file, it **replaces** each ` ```mermaid ` fence with an image and discards the source. That's perfect for a one-shot build, but it means the diagram source no longer lives next to its image — to edit a diagram you need a separate copy of the source.

Native mermaid rendering on GitHub/GitLab doesn't cover this either: the rendered diagram is locked to the file that defines it. There is no image artifact you can reference from other files (see https://github.com/mermaid-js/mermaid/issues/1944), embed in an npm/PyPI readme, or use anywhere Markdown is consumed without mermaid support. I have raised a GitHub discussion about implementing this feature  (https://github.com/orgs/community/discussions/201064).

Downstream tools (e.g. [`render-md-mermaid`](https://github.com/nielsvaneck/render-md-mermaid)) exist purely to work around this: keep the source in the file, hidden in a `<details>` block, and re-render it in place on every push. This PR brings that capability into mermaid-cli itself, in a generic, host-agnostic way.

## What this adds

A `--keep-source` flag for Markdown output. Instead of discarding the source, it keeps it alongside the image, wrapped in round-trip markers:

````md
<!-- mermaid:begin -->

![diagram](./readme-1.svg)

```mermaid
graph LR
  A-->B
```

<!-- mermaid:end -->
````

You can now edit the `mermaid` block and re-run the command to regenerate the image in place. (The blank lines around the markers are deliberate: the emitted Markdown is a no-op under Prettier, so it doesn't fight formatters in the user's repo — there's a test for this.)

### Idempotency is the point

The `<!-- mermaid:begin -->` / `<!-- mermaid:end -->` comments — **not** the visual layout — are the round-trip contract. On a re-run the regex matches the *entire* marker-delimited region and replaces it as a unit, so the image and source are updated together and a new wrapper is **never nested inside the old one**. Running the command on its own output is byte-identical.

Running **without** `--keep-source` on a file that contains keep-source regions converts each region back to a plain image — byte-identical to never having used the flag (there's a test asserting this equality). Since that removes the embedded source from the document, a warning is printed when it happens; it is the only lossy transition.

### Host-agnostic by design, minimal surface

Three flags total, and both layout presets are grounded in standards rather than any vendor: plain CommonMark by default, standard HTML5 `<details>` opt-in.

| flag | behaviour |
|---|---|
| `--keep-source` | keep the source next to the image, wrapped in round-trip markers |
| `--source-style <plain\|collapsed>` | `plain` (default): image + plain fence; `collapsed`: source inside `<details>`/`<summary>` |
| `--source-summary <text>` | label for the `collapsed` summary (default `"Diagram source"`, useful for localization) |

An earlier revision also had a `--source-template` flag for fully custom layouts; I dropped it to keep the surface minimal. The presets are `{{placeholder}}` templates internally, so it can be reintroduced without restructuring if anyone asks for it.

## Implementation notes

- All keep-source machinery lives in a new internal module, `src/keep-source.js` (not part of the public package exports); `src/index.js` gains ~30 lines.
- The Markdown matching regex now also recognizes marker-delimited regions (this is what makes both re-run directions work). For inputs without markers, the bare-fence branch matches exactly what the previous regex matched — the full existing test suite passes unchanged.
- The region-matching branch is tempered so it can never scan across another marker: matching stays linear on adversarial input (no catastrophic backtracking; there's a timing regression test), and a region with a missing end marker can't swallow the diagrams that follow it.

## Tests

Four E2E render tests plus fast unit tests for the regex/template internals in `src-test/test.js`:

- `--keep-source` round trip: markers + source present alongside images, then **re-run on the output is byte-identical** (marker/fence counts unchanged — no nesting).
- `--source-style collapsed` with a custom summary, including the twice-run idempotency check.
- Prettier stability: running Prettier over the emitted Markdown is a no-op, for both styles.
- Strip-back: render with `--keep-source`, re-run without the flag, output equals a never-keep-source render.
- Unit tests: CRLF fences, missing/malformed markers, linear-time matching on marker-heavy input, placeholder semantics (no `$&`/recursive-expansion surprises), unknown style rejection.

Full suite (406 tests), `prettier --check`, `eslint`, and `tsc` all pass locally.

## Open questions for maintainers

- **Scope/naming** — happy to rename flags or trim further (e.g. `--keep-source` alone) if you prefer a smaller surface.
- **SVG determinism** — this makes the *Markdown* idempotent; the generated `.svg` bytes still change per render because mermaid emits random element IDs. That's out of scope here, but it does affect the "commit rendered diagrams in CI" workflow this enables — worth a follow-up (`--deterministic-ids`?) if there's interest.
- **Filename stability on re-run** — image filenames are index-based, so inserting a diagram renumbers those below it. A future revision could reuse the path from the existing image tag instead; kept out of this PR to stay focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
