### PR TITLE
ci: upgrade to GitVersion v6

### DIFF
--- a/.github/workflows/compile-mermaid.yml
+++ b/.github/workflows/compile-mermaid.yml
@@ -22,13 +22,13 @@ jobs:
           fetch-depth: 0
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@51d325634925d7d9ce0a7efc2c586c0bc2b9eee6 # v3.2.1
+        uses: gittools/actions/gitversion/setup@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
         with:
-          versionSpec: "5.x"
+          versionSpec: "6.x"
 
       - name: Use GitVersion
         id: gitversion # step id used as reference for output values
-        uses: gittools/actions/gitversion/execute@51d325634925d7d9ce0a7efc2c586c0bc2b9eee6 # v3.2.1
+        uses: gittools/actions/gitversion/execute@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
 
       - name: Convert repository name to lower case
         run: echo "GITHUB_REPOSITORY_LOWER_CASE=$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -34,13 +34,13 @@ jobs:
         # `npm ci` automatically builds the package
         run: npm ci
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@51d325634925d7d9ce0a7efc2c586c0bc2b9eee6 # v3.2.1
+        uses: gittools/actions/gitversion/setup@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
         with:
-          versionSpec: "5.x"
+          versionSpec: "6.x"
 
       - name: Use GitVersion
         id: gitversion # step id used as reference for output values
-        uses: gittools/actions/gitversion/execute@51d325634925d7d9ce0a7efc2c586c0bc2b9eee6 # v3.2.1
+        uses: gittools/actions/gitversion/execute@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
 
       - name: Get release version
         run: echo "RELEASE_VERSION=${{ steps.gitversion.outputs.semVer }}" >> $GITHUB_ENV

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
 mode: ContinuousDeployment
 branches:
-  master:
-    tag: beta
+  main:
+    label: beta


### PR DESCRIPTION
## :bookmark_tabs: Summary

It looks like the only breaking change that applies to us is that the `tag` field has been renamed to `label`, and that `master` has to be renamed to `main`

See: https://github.com/GitTools/GitVersion/releases?page=2#release-6.0.0
See: https://github.com/GitTools/GitVersion/issues/1054
See: https://github.com/GitTools/GitVersion/issues/5074

This should:
- Close https://github.com/mermaid-js/mermaid-cli/pull/939,
- Close https://github.com/mermaid-js/mermaid-cli/pull/1115, and
- Close https://github.com/mermaid-js/mermaid-cli/pull/1121

## :straight_ruler: Design Decisions

N/A

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
  - Already handled by our existing CI
- [x] :bookmark: targeted `master` branch
