### PR TITLE
docs: add info about markdown output to readme header

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![This project is using Percy.io for visual regression testing.](https://percy.io/static/images/percy-badge.svg)](https://percy.io/Mermaid/mermaid-cli)
 [![Join our Slack!](https://img.shields.io/static/v1?message=join%20chat&color=9cf&logo=slack&label=slack)](https://join.slack.com/t/mermaid-talk/shared_invite/enQtNzc4NDIyNzk4OTAyLWVhYjQxOTI2OTg4YmE1ZmJkY2Y4MTU3ODliYmIwOTY3NDJlYjA0YjIyZTdkMDMyZTUwOGI0NjEzYmEwODcwOTE)
 
-This is a command-line interface (CLI) for [mermaid](https://mermaid.js.org/). It takes a mermaid definition file as input and generates an SVG/PNG/PDF file as output.
+This is a command-line interface (CLI) for [mermaid](https://mermaid.js.org/). It takes a mermaid definition file as input and generates an SVG/PNG/PDF file as output. This CLI also takes a markdown file as input, generates SVG file(s) from mermaid code blocks, before outputting a new markdown file that refers to the aforementioned SVG file(s).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![This project is using Percy.io for visual regression testing.](https://percy.io/static/images/percy-badge.svg)](https://percy.io/Mermaid/mermaid-cli)
 [![Join our Slack!](https://img.shields.io/static/v1?message=join%20chat&color=9cf&logo=slack&label=slack)](https://join.slack.com/t/mermaid-talk/shared_invite/enQtNzc4NDIyNzk4OTAyLWVhYjQxOTI2OTg4YmE1ZmJkY2Y4MTU3ODliYmIwOTY3NDJlYjA0YjIyZTdkMDMyZTUwOGI0NjEzYmEwODcwOTE)
 
-This is a command-line interface (CLI) for [mermaid](https://mermaid.js.org/). It takes a mermaid definition file as input and generates an SVG/PNG/PDF file as output. This CLI also takes a markdown file as input, generates SVG file(s) from mermaid code blocks, before outputting a new markdown file that refers to the aforementioned SVG file(s).
+This is a command-line interface (CLI) for [mermaid](https://mermaid.js.org/). It takes a mermaid definition file as input and generates an SVG/PNG/PDF file as output. There's basic support for converting mermaid code blocks embedded within Markdown files.
 
 ## Installation
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

The first line in the readme mentiones the CLI's ability to output SVG/PNG/PDF output. But, it doesn't mention its ability to work with markdown files, which is hidden further down the readme. 

This PR adds one line to the top of the README about the cli's ability to also generate markdown files using mermaid code blocks and SVG file(s).

Fixes https://github.com/mermaid-js/mermaid-cli/issues/1144