### PR TITLE
Add mmdc to PATH in `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ USER mermaidcli
 WORKDIR /home/mermaidcli
 RUN npm install @mermaid-js/mermaid-cli@$VERSION
 
+ENV PATH="$PATH:/home/mermaidcli/node_modules/.bin/"
+
 ADD puppeteer-config.json  /puppeteer-config.json
 
 WORKDIR /data

--- a/DockerfileBuild
+++ b/DockerfileBuild
@@ -17,7 +17,6 @@ FROM node:18.20-alpine3.19 AS mermaid-cli-current
 WORKDIR /app
 
 COPY --from=build /app/*-mermaid-cli-*.tgz /install/
-COPY --from=build /app/puppeteer-config.json /puppeteer-config.json
 
 ADD install-dependencies.sh install-dependencies.sh
 RUN chmod 755 install-dependencies.sh && /bin/sh install-dependencies.sh
@@ -27,7 +26,10 @@ USER mermaidcli
 WORKDIR /home/mermaidcli
 RUN npm install $(ls -d /install/*.tgz)
 
+ENV PATH="$PATH:/home/mermaidcli/node_modules/.bin/"
+
 ADD puppeteer-config.json  /puppeteer-config.json
+
 WORKDIR /data
 ENTRYPOINT ["/home/mermaidcli/node_modules/.bin/mmdc", "-p", "/puppeteer-config.json"]
 CMD [ "--help" ]

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -4,6 +4,13 @@ IMAGETAG=$2
 
 set -e
 
+# Clean up, even on failure
+cleanup() {
+  rm -rf ./static-out/
+  rm -rf ./test-output/
+}
+trap cleanup EXIT
+
 # If no image tag is provided, build the Docker image
 if [ -z "$IMAGETAG" ]; then
   echo "No image tag provided, building Docker image..."
@@ -102,6 +109,8 @@ if ! grep -q "!\[diagram\](\.\/\.\.\/static-out\/mermaid-artefacts-1\.svg)" "./t
   exit 1;
 fi
 
-# Clean up
-rm -rf ./static-out/
-rm -rf ./test-output/mermaid-artefacts.md
+# Verify that mmdc is on the PATH
+if ! docker run --rm --entrypoint='/bin/sh' $IMAGETAG -c 'mmdc --version' > /dev/null; then
+  echo "mmdc binary is not on the PATH"
+  exit 1;
+fi


### PR DESCRIPTION
## :bookmark_tabs: Summary

Adds mmdc to the PATH in the Docker image

Resolves #1157 

## :straight_ruler: Design Decisions

Edits the PATH variable for both Dockerfiles.

Also:

- removes a redundant puppeteer-config copy

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
